### PR TITLE
Localizer based labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please also cite nnUNet since our work is heavily based on it:
 - [Training](#training)
 - [Inference](#inference)
 - [Localizer based labeling](#localizer-based-labeling)
-- [Output Examples](#output-examples)
+- [Examples](#examples)
 - [List of Classes](#list-of-classes)
 
 ## Model Description
@@ -201,7 +201,7 @@ totalspineseg images output --localizers-dir localizers_output/step2_output --su
 
 Note: If the localizer and main image files have the same names (without suffixes), you can omit the `--suffix` and `--localizers-suffix` arguments.
 
-## Output Examples
+## Examples
 
 TotalSpineSeg demonstrates robust performance across a wide range of imaging parameters. Here are some examples of the model output:
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ output_folder/
 └── step2_output/            # Results of iterative labeling algorithm for step 2 (final output)
 ```
 
+**Important Note:** The spinal cord segmentation provided by TotalSpineSeg is not intended to replace, nor has it been validated for, cross-sectional area (CSA) analysis. Additionally, it has not been tested against spinal cord compressions or MS lesions and should not be used for these purposes. For CSA analysis, please use the validated algorithms available from the [Spinal Cord Toolbox](https://spinalcordtoolbox.com/user_section/tutorials/segmentation.html).
+
 Key points:
 - All segmentations in NIfTI (.nii.gz) format
 - Preview images in JPEG format

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please also cite nnUNet since our work is heavily based on it:
 - [Training](#training)
 - [Inference](#inference)
 - [Localizer based labeling](#localizer-based-labeling)
-- [Examples](#examples)
+- [Results](#results)
 - [List of Classes](#list-of-classes)
 
 ## Model Description
@@ -201,7 +201,7 @@ totalspineseg images output --localizers-dir localizers_output/step2_output --su
 
 Note: If the localizer and main image files have the same names (without suffixes), you can omit the `--suffix` and `--localizers-suffix` arguments.
 
-## Examples
+## Results
 
 TotalSpineSeg demonstrates robust performance across a wide range of imaging parameters. Here are some examples of the model output:
 

--- a/README.md
+++ b/README.md
@@ -135,14 +135,19 @@ Please ensure that your system meets these requirements before proceeding with t
 
 1. Make sure that the `bash` terminal is opened with the virtual environment (if used) activated (using `source <path to installation directory>/venv/bin/activate`).
 
-1. Run the model on a folder containing the images in .nii.gz format:
+1. Run the model on a folder containing the images in .nii.gz format, or on a single .nii.gz file:
    ```bash
-   totalspineseg INPUT_FOLDER OUTPUT_FOLDER [-step1]
+   totalspineseg INPUT OUTPUT_FOLDER [--step1]
    ```
 
-   This will process all .nii.gz files in the INPUT_FOLDER and save the results in the OUTPUT_FOLDER. If you haven't trained the model, the script will automatically download the pre-trained models from the GitHub release.
+   This will process the images in INPUT or the single image and save the results in OUTPUT_FOLDER. If you haven't trained the model, the script will automatically download the pre-trained models from the GitHub release.
 
-   Additionally, you can use the `-step1` parameter to run only the step 1 model, which outputs a single label for all vertebrae, including the sacrum.
+   Additionally, you can use the `--step1` parameter to run only the step 1 model, which outputs a single label for all vertebrae, including the sacrum.
+
+   For more options, you can use the `--help` parameter:
+   ```bash
+   totalspineseg --help
+   ```
 
 **Output Data Structure:**
 
@@ -194,14 +199,14 @@ To use localizer-based labeling:
 totalspineseg localizers localizers_output
 
 # Run model on main images using localizer output
-totalspineseg images output --localizers-dir localizers_output/step2_output --suffix _T2w --localizers-suffix _T1w
+totalspineseg images output --loc localizers_output/step2_output --suffix _T2w --loc-suffix _T1w
 ```
 
-- `--localizers-dir`: Specifies the path to the localizer output
+- `--loc`: Specifies the path to the localizer output
 - `--suffix`: Suffix for the main images (e.g., "_T2w")
-- `--localizers-suffix`: Suffix for the localizer images (e.g., "_T1w")
+- `--loc-suffix`: Suffix for the localizer images (e.g., "_T1w")
 
-Note: If the localizer and main image files have the same names (without suffixes), you can omit the `--suffix` and `--localizers-suffix` arguments.
+Note: If the localizer and main image files have the same names (without suffixes), you can omit the `--suffix` and `--loc-suffix` arguments.
 
 ## Results
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Please ensure that your system meets these requirements before proceeding with t
 
    Additionally, you can use the `-step1` parameter to run only the step 1 model, which outputs a single label for all vertebrae, including the sacrum.
 
-### Output Data Structure:
+**Output Data Structure:**
 
 ```
 output_folder/
@@ -167,7 +167,9 @@ Key points:
 
 ## Localizer based labeling
 
-TotalSpineSeg supports using localizer images to improve the labeling process, particularly useful for images with different fields of view (FOV) where landmarks like C1 and sacrum may not be visible.
+TotalSpineSeg supports using localizer images to improve the labeling process, particularly useful for images with different fields of view (FOV) where landmarks like C1 and sacrum may not be visible. It uses localizer information to accurately label vertebrae and discs in the main image.
+
+![Localizer](https://github.com/user-attachments/assets/5acf0208-a322-46f9-bbde-b3c961a87ec4)
 
 Example of directory structure:
 
@@ -198,10 +200,6 @@ totalspineseg images output --localizers-dir localizers_output/step2_output --su
 - `--localizers-suffix`: Suffix for the localizer images (e.g., "_T1w")
 
 Note: If the localizer and main image files have the same names (without suffixes), you can omit the `--suffix` and `--localizers-suffix` arguments.
-
-This process ensures consistent labeling across images with different FOVs, even when landmarks like C1 or sacrum are not visible. It uses localizer information to accurately label vertebrae and discs in the main image.
-
-![Localizer](https://github.com/user-attachments/assets/5acf0208-a322-46f9-bbde-b3c961a87ec4)
 
 ## Output Examples
 

--- a/README.md
+++ b/README.md
@@ -209,11 +209,7 @@ TotalSpineSeg demonstrates robust performance across a wide range of imaging par
 
 The examples shown above include segmentation results on various contrasts (T1w, T2w, STIR, MTS, T2star, and even CT images), acquisition orientations (sagittal, axial), and resolutions.
 
-For a more detailed view of the output examples, you can check the PDF version:
-
-[Preview PDF](https://github.com/user-attachments/files/16873633/preview.pdf)
-
-The PDF includes step 1 and step 2 results together with the iterative labeling algorithm for each step.
+For a more detailed view of the output examples, you can check the [PDF version](https://github.com/user-attachments/files/16873633/preview.pdf) that includes step 1 and step 2 results together with the iterative labeling algorithm for each step.
 
 ## List of Classes
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ output_folder/
 └── step2_output/            # Results of iterative labeling algorithm for step 2 (final output)
 ```
 
-**Important Note:** The spinal cord segmentation provided by TotalSpineSeg is not intended to replace, nor has it been validated for, cross-sectional area (CSA) analysis. Additionally, it has not been tested against spinal cord compressions or MS lesions and should not be used for these purposes. For CSA analysis, please use the validated algorithms available from the [Spinal Cord Toolbox](https://spinalcordtoolbox.com/user_section/tutorials/segmentation.html).
+**Important Note:** While TotalSpineSeg provides spinal cord segmentation, it is not intended to replace validated methods for cross-sectional area (CSA) analysis. The spinal cord segmentation from TotalSpineSeg has not been validated for CSA measurements, nor has it been tested on cases involving spinal cord compressions, MS lesions, or other spinal cord abnormalities. For accurate CSA analysis, we strongly recommend using the validated algorithms available in the [Spinal Cord Toolbox](https://spinalcordtoolbox.com/user_section/tutorials/segmentation.html).
 
 Key points:
 - All segmentations in NIfTI (.nii.gz) format
@@ -206,7 +206,7 @@ totalspineseg images output --loc localizers_output/step2_output --suffix _T2w -
 - `--suffix`: Suffix for the main images (e.g., "_T2w")
 - `--loc-suffix`: Suffix for the localizer images (e.g., "_T1w")
 
-Note: If the localizer and main image files have the same names (without suffixes), you can omit the `--suffix` and `--loc-suffix` arguments.
+Note: If the localizer and main image files have the same names, you can omit the `--suffix` and `--loc-suffix` arguments.
 
 ## Results
 

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -12,11 +12,12 @@ def main():
     parser = argparse.ArgumentParser(
         description=textwrap.dedent('''
             This script runs inference using the trained TotalSpineSeg nnUNet model.
+            If not already installed, the script will download the pretrained models from the GitHub releases.
         '''),
         epilog=textwrap.dedent('''
             Examples:
-            inference input_folder output_folder
-            inference input_folder output_folder -step1
+            totalspineseg input_folder output_folder
+            totalspineseg input_folder output_folder -step1
         '''),
         formatter_class=argparse.RawTextHelpFormatter
     )
@@ -27,6 +28,24 @@ def main():
     parser.add_argument(
         'output_dir', type=Path,
         help='The output folder where the model outputs will be stored.'
+    )
+    parser.add_argument(
+        '--localizers-dir', '-l', type=Path, default=None,
+        help=' '.join(f'''
+            Folder containing localizers segmentations to use for detecting first vertebrea and disc if C1 and C2-C3 disc or the Sacrum and L5-S disc not found in the image, Optional.
+            This is the output of the model applied on localizer images. It can be the output of step 2, or step 1 if you only want to run step 1 (step1 flag).
+            The algorithm will transform the localizer to the segmentation space and use it to detect the matching vertebrae and discs.
+            Mathcing will based on the magority of the voxels of the first vertebrae or disc in the localizer, that intersect with image.
+            The file names should be in match with the image file names, or you can use the --suffix and --localizers-suffix to match the files.
+        '''.split())
+    )
+    parser.add_argument(
+        '--suffix', '-s', type=str, default='',
+        help='Suffix to use for the input images, defaults to "".'
+    )
+    parser.add_argument(
+        '--localizers-suffix', '-ls', type=str, default='',
+        help='Suffix to use for the localizers labels, defaults to "".'
     )
     parser.add_argument(
         '--step1', action='store_true',
@@ -66,6 +85,9 @@ def main():
     # Get the command-line argument values
     input_path = args.input_dir
     output_path = args.output_dir
+    loc_path = args.localizers_dir
+    suffix = args.suffix
+    loc_suffix = args.localizers_suffix
     step1_only = args.step1
     data_path = args.data_dir
     max_workers = args.max_workers
@@ -117,6 +139,9 @@ def main():
             Running TotalSpineSeg with the following parameters:
             input_dir = "{input_path}"
             output_dir = "{output_path}"
+            localizers_dir = "{loc_path}"
+            suffix = "{suffix}"
+            localizers_suffix = "{loc_suffix}"
             step1_only = {step1_only}
             data_dir = "{data_path}"
             max_workers = {max_workers}
@@ -157,7 +182,7 @@ def main():
     cpdir_mp(
         input_path,
         output_path / 'input',
-        pattern=['*.nii.gz', 'sub-*/anat/*.nii.gz'],
+        pattern=[f'*{suffix}.nii.gz', f'sub-*/anat/*{suffix}.nii.gz'],
         flat=True,
         replace={'.nii.gz': '_0000.nii.gz'},
         override=True,
@@ -250,17 +275,34 @@ def main():
 
     if not quiet: print('\n' 'Using an iterative algorithm to label IVDs with the definite labels:')
     # Labeling is based on the C2-C3, C7-T1 and L5-S1 IVD labels output by step 1 model.
-    iterative_label_mp(
-        output_path / 'step1_output',
-        output_path / 'step1_output',
-        disc_labels=[1, 2, 3, 4, 5],
-        init_disc={2:224, 5:202, 3:219, 4:207},
-        output_disc_step=-1,
-        map_input_dict={6:92, 7:201, 8:201, 9:200},
-        override=True,
-        max_workers=max_workers,
-        quiet=quiet,
-    )
+    if loc_path is None:
+        iterative_label_mp(
+            output_path / 'step1_output',
+            output_path / 'step1_output',
+            disc_labels=[1, 2, 3, 4, 5],
+            init_disc={2:224, 5:202, 3:219, 4:207},
+            output_disc_step=-1,
+            map_input_dict={6:92, 7:201, 8:201, 9:200},
+            override=True,
+            max_workers=max_workers,
+            quiet=quiet,
+        )
+    else:
+        iterative_label_mp(
+            output_path / 'step1_output',
+            output_path / 'step1_output',
+            seg_suffix=suffix,
+            output_seg_suffix=suffix,
+            loc_suffix=loc_suffix,
+            disc_labels=[1, 2, 3, 4, 5],
+            init_disc={2:224, 5:202, 3:219, 4:207},
+            output_disc_step=-1,
+            loc_disc_labels=list(range(202, 225)),
+            map_input_dict={6:92, 7:201, 8:201, 9:200},
+            override=True,
+            max_workers=max_workers,
+            quiet=quiet,
+        )
 
     if not quiet: print('\n' 'Filling spinal cancal label to include all non cord spinal canal:')
     # This will put the spinal canal label in all the voxels between the canal and the cord.
@@ -455,24 +497,49 @@ def main():
         )
 
         if not quiet: print('\n' 'Using an iterative algorithm to label vertebrae and IVDs:')
-        iterative_label_mp(
-            output_path / 'step2_output',
-            output_path / 'step2_output',
-            disc_labels=[1, 2, 3, 4, 5, 6, 7],
-            vertebrea_labels=[9, 10, 11, 12, 13, 14],
-            vertebrea_extra_labels=[8],
-            init_disc={4:224, 7:202, 5:219, 6:207},
-            init_vertebrae={11:40, 14:17, 12:34, 13:23},
-            step_diff_label=True,
-            step_diff_disc=True,
-            output_disc_step=-1,
-            output_vertebrea_step=-1,
-            map_output_dict={17:92},
-            map_input_dict={14:92, 15:201, 16:201, 17:200},
-            override=True,
-            max_workers=max_workers,
-            quiet=quiet,
-        )
+        if loc_path is None:
+            iterative_label_mp(
+                output_path / 'step2_output',
+                output_path / 'step2_output',
+                disc_labels=[1, 2, 3, 4, 5, 6, 7],
+                vertebrea_labels=[9, 10, 11, 12, 13, 14],
+                vertebrea_extra_labels=[8],
+                init_disc={4:224, 7:202, 5:219, 6:207},
+                init_vertebrae={11:40, 14:17, 12:34, 13:23},
+                step_diff_label=True,
+                step_diff_disc=True,
+                output_disc_step=-1,
+                output_vertebrea_step=-1,
+                map_output_dict={17:92},
+                map_input_dict={14:92, 15:201, 16:201, 17:200},
+                override=True,
+                max_workers=max_workers,
+                quiet=quiet,
+            )
+        else:
+            iterative_label_mp(
+                output_path / 'step2_output',
+                output_path / 'step2_output',
+                seg_suffix=suffix,
+                output_seg_suffix=suffix,
+                loc_suffix=loc_suffix,
+                disc_labels=[1, 2, 3, 4, 5, 6, 7],
+                vertebrea_labels=[9, 10, 11, 12, 13, 14],
+                vertebrea_extra_labels=[8],
+                init_disc={4:224, 7:202},
+                init_vertebrae={11:40, 14:17},
+                loc_disc_labels=list(range(202, 225)),
+                loc_vertebrea_labels=list(range(18, 42)) + [92],
+                step_diff_label=True,
+                step_diff_disc=True,
+                output_disc_step=-1,
+                output_vertebrea_step=-1,
+                map_output_dict={17:92},
+                map_input_dict={14:92, 15:201, 16:201, 17:200},
+                override=True,
+                max_workers=max_workers,
+                quiet=quiet,
+            )
 
         if not quiet: print('\n' 'Filling spinal cancal label to include all non cord spinal canal:')
         # This will put the spinal canal label in all the voxels between the canal and the cord.

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -291,11 +291,12 @@ def main():
         iterative_label_mp(
             output_path / 'step1_output',
             output_path / 'step1_output',
+            locs_path=loc_path,
             seg_suffix=suffix,
             output_seg_suffix=suffix,
             loc_suffix=loc_suffix,
             disc_labels=[1, 2, 3, 4, 5],
-            init_disc={2:224, 5:202, 3:219, 4:207},
+            init_disc={2:224, 5:202},
             output_disc_step=-1,
             loc_disc_labels=list(range(202, 225)),
             map_input_dict={6:92, 7:201, 8:201, 9:200},
@@ -520,6 +521,7 @@ def main():
             iterative_label_mp(
                 output_path / 'step2_output',
                 output_path / 'step2_output',
+                locs_path=loc_path,
                 seg_suffix=suffix,
                 output_seg_suffix=suffix,
                 loc_suffix=loc_suffix,

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -41,7 +41,7 @@ def main():
             Folder containing localizers segmentations or a single .nii.gz localizer segmentation to use for detecting first vertebrae and disc if C1 and C2-C3 disc or the Sacrum and L5-S disc not found in the image, Optional.
             This is the output of the model applied on localizer images. It can be the output of step 2, or step 1 if you only want to run step 1 (step1 flag).
             The algorithm will transform the localizer to the segmentation space and use it to detect the matching vertebrae and discs.
-            Mathcing will based on the magority of the voxels of the first vertebrae or disc in the localizer, that intersect with image.
+            Matching will based on the majority of the voxels of the first vertebra or disc in the localizer, that intersect with image.
             The file names should be in match with the image file names, or you can use the --suffix and --loc-suffix to match the files.
         '''.split())
     )

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -40,7 +40,7 @@ def main():
         help=' '.join(f'''
             Folder containing localizers segmentations or a single .nii.gz localizer segmentation to use for detecting first vertebrae and disc if C1 and C2-C3 disc or the Sacrum and L5-S disc not found in the image, Optional.
             This is the output of the model applied on localizer images. It can be the output of step 2, or step 1 if you only want to run step 1 (step1 flag).
-            The algorithm will transform the localizer to the segmentation space and use it to detect the matching vertebrae and discs.
+            The algorithm will use the localizers' segmentations to detect the matching vertebrae and discs. The localizer and the image must be aligned.
             Matching will based on the majority of the voxels of the first vertebra or disc in the localizer, that intersect with image.
             The file names should be in match with the image file names, or you can use the --suffix and --loc-suffix to match the files.
         '''.split())

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -38,7 +38,7 @@ def main():
     parser.add_argument(
         '--loc', '-l', type=Path, default=None,
         help=' '.join(f'''
-            Folder containing localizers segmentations or a single .nii.gz localizer segmentation to use for detecting first vertebrea and disc if C1 and C2-C3 disc or the Sacrum and L5-S disc not found in the image, Optional.
+            Folder containing localizers segmentations or a single .nii.gz localizer segmentation to use for detecting first vertebrae and disc if C1 and C2-C3 disc or the Sacrum and L5-S disc not found in the image, Optional.
             This is the output of the model applied on localizer images. It can be the output of step 2, or step 1 if you only want to run step 1 (step1 flag).
             The algorithm will transform the localizer to the segmentation space and use it to detect the matching vertebrae and discs.
             Mathcing will based on the magority of the voxels of the first vertebrae or disc in the localizer, that intersect with image.
@@ -544,14 +544,14 @@ def main():
                 output_path / 'step2_output',
                 output_path / 'step2_output',
                 disc_labels=[1, 2, 3, 4, 5, 6, 7],
-                vertebrea_labels=[9, 10, 11, 12, 13, 14],
-                vertebrea_extra_labels=[8],
+                vertebrae_labels=[9, 10, 11, 12, 13, 14],
+                vertebrae_extra_labels=[8],
                 init_disc={4:224, 7:202, 5:219, 6:207},
                 init_vertebrae={11:40, 14:17, 12:34, 13:23},
                 step_diff_label=True,
                 step_diff_disc=True,
                 output_disc_step=-1,
-                output_vertebrea_step=-1,
+                output_vertebrae_step=-1,
                 map_output_dict={17:92},
                 map_input_dict={14:92, 15:201, 16:201, 17:200},
                 override=True,
@@ -564,16 +564,16 @@ def main():
                 output_path / 'step2_output',
                 locs_path=output_path / 'localizers',
                 disc_labels=[1, 2, 3, 4, 5, 6, 7],
-                vertebrea_labels=[9, 10, 11, 12, 13, 14],
-                vertebrea_extra_labels=[8],
+                vertebrae_labels=[9, 10, 11, 12, 13, 14],
+                vertebrae_extra_labels=[8],
                 init_disc={4:224, 7:202},
                 init_vertebrae={11:40, 14:17},
                 loc_disc_labels=list(range(202, 225)),
-                loc_vertebrea_labels=list(range(18, 42)) + [92],
+                loc_vertebrae_labels=list(range(18, 42)) + [92],
                 step_diff_label=True,
                 step_diff_disc=True,
                 output_disc_step=-1,
-                output_vertebrea_step=-1,
+                output_vertebrae_step=-1,
                 map_output_dict={17:92},
                 map_input_dict={14:92, 15:201, 16:201, 17:200},
                 override=True,

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -85,7 +85,7 @@ def main():
     # Get the command-line argument values
     input_path = args.input_dir
     output_path = args.output_dir
-    loc_path = args.localizers_dir
+    locs_path = args.localizers_dir
     suffix = args.suffix
     loc_suffix = args.localizers_suffix
     step1_only = args.step1
@@ -139,7 +139,7 @@ def main():
             Running TotalSpineSeg with the following parameters:
             input_dir = "{input_path}"
             output_dir = "{output_path}"
-            localizers_dir = "{loc_path}"
+            localizers_dir = "{locs_path}"
             suffix = "{suffix}"
             localizers_suffix = "{loc_suffix}"
             step1_only = {step1_only}
@@ -275,7 +275,7 @@ def main():
 
     if not quiet: print('\n' 'Using an iterative algorithm to label IVDs with the definite labels:')
     # Labeling is based on the C2-C3, C7-T1 and L5-S1 IVD labels output by step 1 model.
-    if loc_path is None:
+    if locs_path is None:
         iterative_label_mp(
             output_path / 'step1_output',
             output_path / 'step1_output',
@@ -291,7 +291,7 @@ def main():
         iterative_label_mp(
             output_path / 'step1_output',
             output_path / 'step1_output',
-            locs_path=loc_path,
+            locs_path=locs_path,
             seg_suffix=suffix,
             output_seg_suffix=suffix,
             loc_suffix=loc_suffix,
@@ -498,7 +498,7 @@ def main():
         )
 
         if not quiet: print('\n' 'Using an iterative algorithm to label vertebrae and IVDs:')
-        if loc_path is None:
+        if locs_path is None:
             iterative_label_mp(
                 output_path / 'step2_output',
                 output_path / 'step2_output',
@@ -521,7 +521,7 @@ def main():
             iterative_label_mp(
                 output_path / 'step2_output',
                 output_path / 'step2_output',
-                locs_path=loc_path,
+                locs_path=locs_path,
                 seg_suffix=suffix,
                 output_seg_suffix=suffix,
                 loc_suffix=loc_suffix,

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -209,7 +209,7 @@ def main():
         (output_path / 'localizers').mkdir(parents=True, exist_ok=True)
 
         # List all localizers in the localizers folder
-        locs = list(loc_path.glob(f'*{loc_suffix}.nii.gz'))
+        locs = list(loc_path.glob(f'*{loc_suffix}.nii.gz')) + list(loc_path.glob(f'sub-*/anat/*{loc_suffix}.nii.gz'))
 
         # Copy the localizers to the output folder
         for image in (output_path / 'input').glob('*_0000.nii.gz'):
@@ -222,6 +222,17 @@ def main():
                 loc = next((_ for _ in locs if fnmatch(image.name, _.name.replace(f'{loc_suffix}.nii.gz', f'{image_suffix}_0000.nii.gz'))), None)
             if loc:
                 shutil.copy(loc, output_path / 'localizers' / image.name.replace('_0000.nii.gz', f'.nii.gz'))
+
+        if not quiet: print('\n' 'Generating preview images for the localizers:')
+        preview_jpg_mp(
+            output_path / 'input',
+            output_path / 'preview',
+            segs_path=output_path / 'localizers',
+            output_suffix='_loc',
+            override=True,
+            max_workers=max_workers,
+            quiet=quiet,
+        )
 
     if not quiet: print('\n' 'Converting 4D images to 3D:')
     average4d_mp(

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -18,9 +18,9 @@ def main():
         '''.split()),
         epilog=textwrap.dedent('''
             Examples:
-            extract_levels -s labels_init -o labels --disc-labels 1 2 3 4 5 6 7 --vertebrea-labels 9 10 11 12 13 14 --vertebrea-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrea-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
+            extract_levels -s labels_init -o labels --disc-labels 1 2 3 4 5 6 7 --vertebrae-labels 9 10 11 12 13 14 --vertebrae-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrae-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
             For BIDS:
-            extract_levels -s derivatives/labels -o derivatives/labels --seg-suffix "_seg" --output-seg-suffix "_seg_seq" -d "sub-" -u "anat" --disc-labels 1 2 3 4 5 6 7 --vertebrea-labels 9 10 11 12 13 14 --vertebrea-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrea-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
+            extract_levels -s derivatives/labels -o derivatives/labels --seg-suffix "_seg" --output-seg-suffix "_seg_seq" -d "sub-" -u "anat" --disc-labels 1 2 3 4 5 6 7 --vertebrae-labels 9 10 11 12 13 14 --vertebrae-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrae-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
         '''),
         formatter_class=argparse.RawTextHelpFormatter
     )

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -18,9 +18,9 @@ def main():
         '''.split()),
         epilog=textwrap.dedent('''
             Examples:
-            extract_levels -s labels_init -o labels --disc-labels 1 2 3 4 5 6 7 --vertebrae-labels 9 10 11 12 13 14 --vertebrae-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrae-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
+            extract_levels -s labels -o levels --canal-labels 200 201 --c2c3-label 224 --step -1 -r
             For BIDS:
-            extract_levels -s derivatives/labels -o derivatives/labels --seg-suffix "_seg" --output-seg-suffix "_seg_seq" -d "sub-" -u "anat" --disc-labels 1 2 3 4 5 6 7 --vertebrae-labels 9 10 11 12 13 14 --vertebrae-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrae-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
+            extract_levels -s derivatives/labels -o derivatives/labels --seg-suffix "_seg" --output-seg-suffix "_levels" -d "sub-" -u "anat" --canal-labels 200 201 --c2c3-label 224 --step -1 -r
         '''),
         formatter_class=argparse.RawTextHelpFormatter
     )

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -38,7 +38,11 @@ def main():
     )
     parser.add_argument(
         '--locs-dir', '-l', type=Path, default=None,
-        help='Folder containing localizers to use for detecting first vertebrea and disc if init label not found, Optional.'
+        help=' '.join(f'''
+            Folder containing localizers segmentations to use for detecting first vertebrea and disc if init label not found, Optional.
+            The algorithm will transform the localizer to the segmentation space and use it to detect the matching vertebrae and disc if the init label not found.
+            Mathcing will based on the magority of the voxels of the first vertebrae or disc in the localizer, that intersect with the input segmentation.
+        '''.split())
     )
     parser.add_argument(
         '--subject-dir', '-d', type=str, default=None, nargs='?', const='',

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -656,12 +656,13 @@ def iterative_label(
             mask = np.isin(loc_data, loc_labels) * np.isin(mask_labeled, sorted_labels)
 
             # Get the first label from sorted_labels that is in the localizer specified labels
-            first_sorted_labels_in_loc = next(np.array(sorted_labels)[np.isin(sorted_labels, mask * mask_labeled)].flat, 0)
+            mask_labeled_masked = mask * mask_labeled
+            first_sorted_labels_in_loc = next(np.array(sorted_labels)[np.isin(sorted_labels, mask_labeled_masked)].flat, 0)
 
             if first_sorted_labels_in_loc > 0:
-                # Get the target label in the segmentation
+                # Get the target label for first_sorted_labels_in_loc - the label from the localizer that has the most voxels in it
                 loc_data_masked = mask * loc_data
-                target = np.argmax(np.bincount(loc_data_masked[mask_labeled == first_sorted_labels_in_loc].flat))
+                target = np.argmax(np.bincount(loc_data_masked[mask_labeled_masked == first_sorted_labels_in_loc].flat))
                 # If target in map_output_dict reverse it from the reversed map
                 # TODO Edge case if multiple keys have the same value, not used in the current implementation
                 target = {v: k for k, v in map_output_dict.items()}.get(target, target)

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -20,10 +20,10 @@ def main():
         '''.split()),
         epilog=textwrap.dedent('''
             Examples:
-            iterative_label -s labels_init -o labels --disc-labels 1-7 --vertebrea-labels 9-14 --vertebrea-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrea-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
-            iterative_label -s labels_init -o labels -l localizers --disc-labels 1-7 --vertebrea-labels 9-14 --vertebrea-extra-labels 8 --init-disc 4:224 7:202 --init-vertebrae 11:40 14:17 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrea-step -1 --loc-disc-labels 202-224 --loc-vertebrea-labels 18-41 92 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
+            iterative_label -s labels_init -o labels --disc-labels 1-7 --vertebrae-labels 9-14 --vertebrae-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrae-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
+            iterative_label -s labels_init -o labels -l localizers --disc-labels 1-7 --vertebrae-labels 9-14 --vertebrae-extra-labels 8 --init-disc 4:224 7:202 --init-vertebrae 11:40 14:17 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrae-step -1 --loc-disc-labels 202-224 --loc-vertebrae-labels 18-41 92 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
             For BIDS:
-            iterative_label -s derivatives/labels -o derivatives/labels --seg-suffix "_seg" --output-seg-suffix "_seg_seq" -d "sub-" -u "anat" --disc-labels 1 2 3 4 5 6 7 --vertebrea-labels 9 10 11 12 13 14 --vertebrea-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrea-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
+            iterative_label -s derivatives/labels -o derivatives/labels --seg-suffix "_seg" --output-seg-suffix "_seg_seq" -d "sub-" -u "anat" --disc-labels 1 2 3 4 5 6 7 --vertebrae-labels 9 10 11 12 13 14 --vertebrae-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrae-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
         '''),
         formatter_class=argparse.RawTextHelpFormatter
     )
@@ -39,7 +39,7 @@ def main():
     parser.add_argument(
         '--locs-dir', '-l', type=Path, default=None,
         help=' '.join(f'''
-            Folder containing localizers segmentations to use for detecting first vertebrea and disc if init label not found, Optional.
+            Folder containing localizers segmentations to use for detecting first vertebrae and disc if init label not found, Optional.
             The algorithm will transform the localizer to the segmentation space and use it to detect the matching vertebrae and disc if the init label not found.
             Mathcing will based on the magority of the voxels of the first vertebrae or disc in the localizer, that intersect with the input segmentation.
         '''.split())
@@ -89,11 +89,11 @@ def main():
         help='The disc labels in the localizer used for detecting first disc.'
     )
     parser.add_argument(
-        '--vertebrea-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
+        '--vertebrae-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
         help='The vertebrae labels.'
     )
     parser.add_argument(
-        '--vertebrea-extra-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
+        '--vertebrae-extra-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
         help='Extra vertebrae labels to add to add to adjacent vertebrae labels.'
     )
     parser.add_argument(
@@ -101,11 +101,11 @@ def main():
         help='Init labels list for vertebrae ordered by priority (input_label:output_label !!without space!!). for example 10:41 11:34 12:18'
     )
     parser.add_argument(
-        '--output-vertebrea-step', type=int, default=1,
+        '--output-vertebrae-step', type=int, default=1,
         help='The step to take between vertebrae labels in the output, defaults to 1.'
     )
     parser.add_argument(
-        '--loc-vertebrea-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
+        '--loc-vertebrae-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
         help='The disc labels in the localizer used for detecting first vertebrae.'
     )
     parser.add_argument(
@@ -148,7 +148,7 @@ def main():
         help='Default superior disc label if no init label found, defaults to 0 (Raise error if init label not found).'
     )
     parser.add_argument(
-        '--default-superior-vertebrea', type=int, default=0,
+        '--default-superior-vertebrae', type=int, default=0,
         help='Default superior vertebrae label if no init label found, defaults to 0 (Raise error if init label not found).'
     )
     parser.add_argument(
@@ -181,18 +181,18 @@ def main():
     init_disc = dict(args.init_disc)
     output_disc_step = args.output_disc_step
     loc_disc_labels = [_ for __ in args.loc_disc_labels for _ in (__ if isinstance(__, list) else [__])]
-    vertebrea_labels = [_ for __ in args.vertebrea_labels for _ in (__ if isinstance(__, list) else [__])]
-    vertebrea_extra_labels = [_ for __ in args.vertebrea_extra_labels for _ in (__ if isinstance(__, list) else [__])]
+    vertebrae_labels = [_ for __ in args.vertebrae_labels for _ in (__ if isinstance(__, list) else [__])]
+    vertebrae_extra_labels = [_ for __ in args.vertebrae_extra_labels for _ in (__ if isinstance(__, list) else [__])]
     init_vertebrae = dict(args.init_vertebrae)
-    output_vertebrea_step = args.output_vertebrea_step
-    loc_vertebrea_labels = [_ for __ in args.loc_vertebrea_labels for _ in (__ if isinstance(__, list) else [__])]
+    output_vertebrae_step = args.output_vertebrae_step
+    loc_vertebrae_labels = [_ for __ in args.loc_vertebrae_labels for _ in (__ if isinstance(__, list) else [__])]
     map_input_list = args.map_input
     map_output_list = args.map_output
     dilation_size = args.dilation_size
     step_diff_label = args.step_diff_label
     step_diff_disc = args.step_diff_disc
     default_superior_disc = args.default_superior_disc
-    default_superior_vertebrea = args.default_superior_vertebrea
+    default_superior_vertebrae = args.default_superior_vertebrae
     override = args.override
     max_workers = args.max_workers
     quiet = args.quiet
@@ -214,18 +214,18 @@ def main():
             init_disc = {init_disc}
             output_disc_step = {output_disc_step}
             loc_disc_labels = {loc_disc_labels}
-            vertebrea_labels = {vertebrea_labels}
-            vertebrea_extra_labels = {vertebrea_extra_labels}
+            vertebrae_labels = {vertebrae_labels}
+            vertebrae_extra_labels = {vertebrae_extra_labels}
             init_vertebrae = {init_vertebrae}
-            output_vertebrea_step = {output_vertebrea_step}
-            loc_vertebrea_labels = {loc_vertebrea_labels}
+            output_vertebrae_step = {output_vertebrae_step}
+            loc_vertebrae_labels = {loc_vertebrae_labels}
             map_input = {map_input_list}
             map_output = {map_output_list}
             dilation_size = {dilation_size}
             step_diff_label = {step_diff_label}
             step_diff_disc = {step_diff_disc}
             default_superior_disc = {default_superior_disc}
-            default_superior_vertebrea = {default_superior_vertebrea}
+            default_superior_vertebrae = {default_superior_vertebrae}
             override = {override}
             max_workers = {max_workers}
             quiet = {quiet}
@@ -256,18 +256,18 @@ def main():
         init_disc=init_disc,
         output_disc_step=output_disc_step,
         loc_disc_labels=loc_disc_labels,
-        vertebrea_labels=vertebrea_labels,
-        vertebrea_extra_labels=vertebrea_extra_labels,
+        vertebrae_labels=vertebrae_labels,
+        vertebrae_extra_labels=vertebrae_extra_labels,
         init_vertebrae=init_vertebrae,
-        output_vertebrea_step=output_vertebrea_step,
-        loc_vertebrea_labels=loc_vertebrea_labels,
+        output_vertebrae_step=output_vertebrae_step,
+        loc_vertebrae_labels=loc_vertebrae_labels,
         map_input_dict=map_input_dict,
         map_output_dict=map_output_dict,
         dilation_size=dilation_size,
         step_diff_label=step_diff_label,
         step_diff_disc=step_diff_disc,
         default_superior_disc=default_superior_disc,
-        default_superior_vertebrea=default_superior_vertebrea,
+        default_superior_vertebrae=default_superior_vertebrae,
         override=override,
         max_workers=max_workers,
         quiet=quiet,
@@ -287,18 +287,18 @@ def iterative_label_mp(
         init_disc={},
         output_disc_step=1,
         loc_disc_labels=[],
-        vertebrea_labels=[],
-        vertebrea_extra_labels=[],
+        vertebrae_labels=[],
+        vertebrae_extra_labels=[],
         init_vertebrae={},
-        output_vertebrea_step=1,
-        loc_vertebrea_labels=[],
+        output_vertebrae_step=1,
+        loc_vertebrae_labels=[],
         map_input_dict={},
         map_output_dict={},
         dilation_size=1,
         step_diff_label=False,
         step_diff_disc=False,
         default_superior_disc=0,
-        default_superior_vertebrea=0,
+        default_superior_vertebrae=0,
         override=False,
         max_workers=mp.cpu_count(),
         quiet=False,
@@ -329,18 +329,18 @@ def iterative_label_mp(
             output_disc_step=output_disc_step,
             loc_disc_labels=loc_disc_labels,
             init_disc=init_disc,
-            vertebrea_labels=vertebrea_labels,
-            vertebrea_extra_labels=vertebrea_extra_labels,
+            vertebrae_labels=vertebrae_labels,
+            vertebrae_extra_labels=vertebrae_extra_labels,
             init_vertebrae=init_vertebrae,
-            output_vertebrea_step=output_vertebrea_step,
-            loc_vertebrea_labels=loc_vertebrea_labels,
+            output_vertebrae_step=output_vertebrae_step,
+            loc_vertebrae_labels=loc_vertebrae_labels,
             map_input_dict=map_input_dict,
             map_output_dict=map_output_dict,
             dilation_size=dilation_size,
             step_diff_label=step_diff_label,
             step_diff_disc=step_diff_disc,
             default_superior_disc=default_superior_disc,
-            default_superior_vertebrea=default_superior_vertebrea,
+            default_superior_vertebrae=default_superior_vertebrae,
             override=override,
         ),
         seg_path_list,
@@ -359,18 +359,18 @@ def _iterative_label(
         init_disc={},
         output_disc_step=1,
         loc_disc_labels=[],
-        vertebrea_labels=[],
-        vertebrea_extra_labels=[],
+        vertebrae_labels=[],
+        vertebrae_extra_labels=[],
         init_vertebrae={},
-        output_vertebrea_step=1,
-        loc_vertebrea_labels=[],
+        output_vertebrae_step=1,
+        loc_vertebrae_labels=[],
         map_input_dict={},
         map_output_dict={},
         dilation_size=1,
         step_diff_label=False,
         step_diff_disc=False,
         default_superior_disc=0,
-        default_superior_vertebrea=0,
+        default_superior_vertebrae=0,
         override=False,
     ):
     '''
@@ -396,18 +396,18 @@ def _iterative_label(
             init_disc=init_disc,
             output_disc_step=output_disc_step,
             loc_disc_labels=loc_disc_labels,
-            vertebrea_labels=vertebrea_labels,
-            vertebrea_extra_labels=vertebrea_extra_labels,
+            vertebrae_labels=vertebrae_labels,
+            vertebrae_extra_labels=vertebrae_extra_labels,
             init_vertebrae=init_vertebrae,
-            output_vertebrea_step=output_vertebrea_step,
-            loc_vertebrea_labels=loc_vertebrea_labels,
+            output_vertebrae_step=output_vertebrae_step,
+            loc_vertebrae_labels=loc_vertebrae_labels,
             map_input_dict=map_input_dict,
             map_output_dict=map_output_dict,
             dilation_size=dilation_size,
             step_diff_label=step_diff_label,
             step_diff_disc=step_diff_disc,
             default_superior_disc=default_superior_disc,
-            default_superior_vertebrea=default_superior_vertebrea,
+            default_superior_vertebrae=default_superior_vertebrae,
         )
     except ValueError as e:
         output_seg_path.is_file() and output_seg_path.unlink()
@@ -434,18 +434,18 @@ def iterative_label(
         init_disc={},
         output_disc_step=1,
         loc_disc_labels=[],
-        vertebrea_labels=[],
-        vertebrea_extra_labels=[],
+        vertebrae_labels=[],
+        vertebrae_extra_labels=[],
         init_vertebrae={},
-        output_vertebrea_step=1,
-        loc_vertebrea_labels=[],
+        output_vertebrae_step=1,
+        loc_vertebrae_labels=[],
         map_input_dict={},
         map_output_dict={},
         dilation_size=1,
         step_diff_label=False,
         step_diff_disc=False,
         default_superior_disc=0,
-        default_superior_vertebrea=0,
+        default_superior_vertebrae=0,
     ):
     '''
     Label Vertebrae, IVDs, Spinal Cord and canal from init segmentation.
@@ -462,7 +462,7 @@ def iterative_label(
     seg : nibabel.nifti1.Nifti1Image
         Segmentation image
     loc : nibabel.nifti1.Nifti1Image
-        Localizer image to use for detecting first vertebrea and disc (optional)
+        Localizer image to use for detecting first vertebrae and disc (optional)
     disc_labels : list
         The disc labels
     init_disc : dict
@@ -471,15 +471,15 @@ def iterative_label(
         The step to take between disc labels in the output
     loc_disc_labels : list
         Localizer labels to use for detecting first disc
-    vertebrea_labels : list
+    vertebrae_labels : list
         The vertebrae labels
-    vertebrea_extra_labels : list
+    vertebrae_extra_labels : list
         Extra vertebrae labels to add to add to adjacent vertebrae labels
     init_vertebrae : dict
         Init labels list for vertebrae ordered by priority (input_label:output_label)
-    output_vertebrea_step : int
+    output_vertebrae_step : int
         The step to take between vertebrae labels in the output
-    loc_vertebrea_labels : list
+    loc_vertebrae_labels : list
         Localizer labels to use for detecting first vertebrae
     map_input_dict : dict
         A dict mapping labels from input into the output segmentation
@@ -493,7 +493,7 @@ def iterative_label(
         Make step only for different discs
     default_superior_disc : int
         Default superior disc label if no init label found
-    default_superior_vertebrea : int
+    default_superior_vertebrae : int
         Default superior vertebrae label if no init label found
 
     Returns
@@ -523,7 +523,7 @@ def iterative_label(
     # We run the same iterative algorithm for discs and vertebrae
     for labels, extra_labels, step, init, default_sup, loc_labels, is_vert in (
         (disc_labels, [], output_disc_step, init_disc, default_superior_disc, loc_disc_labels, False),
-        (vertebrea_labels, vertebrea_extra_labels, output_vertebrea_step, init_vertebrae, default_superior_vertebrea, loc_vertebrea_labels, True)):
+        (vertebrae_labels, vertebrae_extra_labels, output_vertebrae_step, init_vertebrae, default_superior_vertebrae, loc_vertebrae_labels, True)):
 
         # Skip if no labels are provided
         if len(labels) == 0:

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -6,6 +6,7 @@ import nibabel as nib
 import multiprocessing as mp
 from functools import partial
 from tqdm.contrib.concurrent import process_map
+import torchio as tio
 import warnings
 
 warnings.filterwarnings("ignore")
@@ -19,7 +20,8 @@ def main():
         '''.split()),
         epilog=textwrap.dedent('''
             Examples:
-            iterative_label -s labels_init -o labels --disc-labels 1 2 3 4 5 6 7 --vertebrea-labels 9 10 11 12 13 14 --vertebrea-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrea-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
+            iterative_label -s labels_init -o labels --disc-labels 1-7 --vertebrea-labels 9-14 --vertebrea-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrea-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
+            iterative_label -s labels_init -o labels -l localizers --disc-labels 1-7 --vertebrea-labels 9-14 --vertebrea-extra-labels 8 --init-disc 4:224 7:202 --init-vertebrae 11:40 14:17 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrea-step -1 --loc-disc-labels 202-224 --loc-vertebrea-labels 18-41 92 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
             For BIDS:
             iterative_label -s derivatives/labels -o derivatives/labels --seg-suffix "_seg" --output-seg-suffix "_seg_seq" -d "sub-" -u "anat" --disc-labels 1 2 3 4 5 6 7 --vertebrea-labels 9 10 11 12 13 14 --vertebrea-extra-labels 8 --init-disc 4:224 7:202 5:219 6:207 --init-vertebrae 11:40 14:17 12:34 13:23 --step-diff-label --step-diff-disc --output-disc-step -1 --output-vertebrea-step -1 --map-output 17:92 --map-input 14:92 16:201 17:200 -r
         '''),
@@ -33,6 +35,10 @@ def main():
     parser.add_argument(
         '--output-segs-dir', '-o', type=Path, required=True,
         help='Folder to save output segmentations.'
+    )
+    parser.add_argument(
+        '--locs-dir', '-l', type=Path, default=None,
+        help='Folder containing localizers to use for detecting first vertebrea and disc if init label not found, Optional.'
     )
     parser.add_argument(
         '--subject-dir', '-d', type=str, default=None, nargs='?', const='',
@@ -59,7 +65,11 @@ def main():
         help='Suffix for output segmentation, defaults to "".'
     )
     parser.add_argument(
-        '--disc-labels', type=int, nargs='+', default=[],
+        '--loc-suffix', type=str, default='',
+        help='Localizer suffix, defaults to "".'
+    )
+    parser.add_argument(
+        '--disc-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
         help='The disc labels.'
     )
     parser.add_argument(
@@ -71,11 +81,15 @@ def main():
         help='The step to take between disc labels in the output, defaults to 1.'
     )
     parser.add_argument(
-        '--vertebrea-labels', type=int, nargs='+', default=[],
+        '--loc-disc-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
+        help='The disc labels.'
+    )
+    parser.add_argument(
+        '--vertebrea-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
         help='The vertebrae labels.'
     )
     parser.add_argument(
-        '--vertebrea-extra-labels', type=int, nargs='+', default=[],
+        '--vertebrea-extra-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
         help='Extra vertebrae labels to add to add to adjacent vertebrae labels.'
     )
     parser.add_argument(
@@ -85,6 +99,10 @@ def main():
     parser.add_argument(
         '--output-vertebrea-step', type=int, default=1,
         help='The step to take between vertebrae labels in the output, defaults to 1.'
+    )
+    parser.add_argument(
+        '--loc-vertebrea-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
+        help='The disc labels.'
     )
     parser.add_argument(
         '--map-input', type=str, nargs='+', default=[],
@@ -122,6 +140,14 @@ def main():
         '''.split())
     )
     parser.add_argument(
+        '--default-superior-disc', type=int, default=0,
+        help='Default superior disc label if no init label found, defaults to 0 (Raise error if init label not found).'
+    )
+    parser.add_argument(
+        '--default-superior-vertebrea', type=int, default=0,
+        help='Default superior vertebrae label if no init label found, defaults to 0 (Raise error if init label not found).'
+    )
+    parser.add_argument(
         '--override', '-r', action="store_true", default=False,
         help='Override existing output files, defaults to false (Do not override).'
     )
@@ -140,23 +166,29 @@ def main():
     # Get arguments
     segs_path = args.segs_dir
     output_segs_path = args.output_segs_dir
+    locs_path = args.locs_dir
     subject_dir = args.subject_dir
     subject_subdir = args.subject_subdir
     prefix = args.prefix
     seg_suffix = args.seg_suffix
     output_seg_suffix = args.output_seg_suffix
-    disc_labels = args.disc_labels
+    loc_suffix = args.loc_suffix
+    disc_labels = [_ for __ in args.disc_labels for _ in (__ if isinstance(__, list) else [__])]
     init_disc = dict(args.init_disc)
     output_disc_step = args.output_disc_step
-    vertebrea_labels = args.vertebrea_labels
-    vertebrea_extra_labels = args.vertebrea_extra_labels
+    loc_disc_labels = [_ for __ in args.loc_disc_labels for _ in (__ if isinstance(__, list) else [__])]
+    vertebrea_labels = [_ for __ in args.vertebrea_labels for _ in (__ if isinstance(__, list) else [__])]
+    vertebrea_extra_labels = [_ for __ in args.vertebrea_extra_labels for _ in (__ if isinstance(__, list) else [__])]
     init_vertebrae = dict(args.init_vertebrae)
     output_vertebrea_step = args.output_vertebrea_step
+    loc_vertebrea_labels = [_ for __ in args.loc_vertebrea_labels for _ in (__ if isinstance(__, list) else [__])]
     map_input_list = args.map_input
     map_output_list = args.map_output
     dilation_size = args.dilation_size
     step_diff_label = args.step_diff_label
     step_diff_disc = args.step_diff_disc
+    default_superior_disc = args.default_superior_disc
+    default_superior_vertebrea = args.default_superior_vertebrea
     override = args.override
     max_workers = args.max_workers
     quiet = args.quiet
@@ -167,23 +199,29 @@ def main():
             Running {Path(__file__).stem} with the following params:
             segs_dir = "{segs_path}"
             output_segs_dir = "{output_segs_path}"
+            locs_dir = "{locs_path}"
             subject_dir = "{subject_dir}"
             subject_subdir = "{subject_subdir}"
             prefix = "{prefix}"
             seg_suffix = "{seg_suffix}"
             output_seg_suffix = "{output_seg_suffix}"
+            loc_suffix = "{loc_suffix}"
             disc_labels = {disc_labels}
             init_disc = {init_disc}
             output_disc_step = {output_disc_step}
+            loc_disc_labels = {loc_disc_labels}
             vertebrea_labels = {vertebrea_labels}
             vertebrea_extra_labels = {vertebrea_extra_labels}
             init_vertebrae = {init_vertebrae}
             output_vertebrea_step = {output_vertebrea_step}
+            loc_vertebrea_labels = {loc_vertebrea_labels}
             map_input = {map_input_list}
             map_output = {map_output_list}
             dilation_size = {dilation_size}
             step_diff_label = {step_diff_label}
             step_diff_disc = {step_diff_disc}
+            default_superior_disc = {default_superior_disc}
+            default_superior_vertebrea = {default_superior_vertebrea}
             override = {override}
             max_workers = {max_workers}
             quiet = {quiet}
@@ -203,23 +241,29 @@ def main():
     iterative_label_mp(
         segs_path=segs_path,
         output_segs_path=output_segs_path,
+        locs_path=locs_path,
         subject_dir=subject_dir,
         subject_subdir=subject_subdir,
         prefix=prefix,
         seg_suffix=seg_suffix,
         output_seg_suffix=output_seg_suffix,
+        loc_suffix=loc_suffix,
         disc_labels=disc_labels,
         init_disc=init_disc,
         output_disc_step=output_disc_step,
+        loc_disc_labels=loc_disc_labels,
         vertebrea_labels=vertebrea_labels,
         vertebrea_extra_labels=vertebrea_extra_labels,
         init_vertebrae=init_vertebrae,
         output_vertebrea_step=output_vertebrea_step,
+        loc_vertebrea_labels=loc_vertebrea_labels,
         map_input_dict=map_input_dict,
         map_output_dict=map_output_dict,
         dilation_size=dilation_size,
         step_diff_label=step_diff_label,
         step_diff_disc=step_diff_disc,
+        default_superior_disc=default_superior_disc,
+        default_superior_vertebrea=default_superior_vertebrea,
         override=override,
         max_workers=max_workers,
         quiet=quiet,
@@ -228,23 +272,29 @@ def main():
 def iterative_label_mp(
         segs_path,
         output_segs_path,
+        locs_path=None,
         subject_dir=None,
         subject_subdir='',
         prefix='',
         seg_suffix='',
         output_seg_suffix='',
+        loc_suffix='',
         disc_labels=[],
         init_disc={},
         output_disc_step=1,
+        loc_disc_labels=[],
         vertebrea_labels=[],
         vertebrea_extra_labels=[],
         init_vertebrae={},
         output_vertebrea_step=1,
+        loc_vertebrea_labels=[],
         map_input_dict={},
         map_output_dict={},
         dilation_size=1,
         step_diff_label=False,
         step_diff_disc=False,
+        default_superior_disc=0,
+        default_superior_vertebrea=0,
         override=False,
         max_workers=mp.cpu_count(),
         quiet=False,
@@ -254,6 +304,7 @@ def iterative_label_mp(
     '''
     segs_path = Path(segs_path)
     output_segs_path = Path(output_segs_path)
+    locs_path = locs_path and Path(locs_path)
 
     glob_pattern = ""
     if subject_dir is not None:
@@ -265,26 +316,32 @@ def iterative_label_mp(
     # Process the NIfTI image and segmentation files
     seg_path_list = list(segs_path.glob(glob_pattern))
     output_seg_path_list = [output_segs_path / _.relative_to(segs_path).parent / _.name.replace(f'{seg_suffix}.nii.gz', f'{output_seg_suffix}.nii.gz') for _ in seg_path_list]
+    loc_path_list = [locs_path and locs_path / _.relative_to(segs_path).parent / _.name.replace(f'{seg_suffix}.nii.gz', f'{loc_suffix}.nii.gz') for _ in seg_path_list]
 
     process_map(
         partial(
             _iterative_label,
             disc_labels=disc_labels,
             output_disc_step=output_disc_step,
+            loc_disc_labels=loc_disc_labels,
             init_disc=init_disc,
             vertebrea_labels=vertebrea_labels,
             vertebrea_extra_labels=vertebrea_extra_labels,
             init_vertebrae=init_vertebrae,
             output_vertebrea_step=output_vertebrea_step,
+            loc_vertebrea_labels=loc_vertebrea_labels,
             map_input_dict=map_input_dict,
             map_output_dict=map_output_dict,
             dilation_size=dilation_size,
             step_diff_label=step_diff_label,
             step_diff_disc=step_diff_disc,
+            default_superior_disc=default_superior_disc,
+            default_superior_vertebrea=default_superior_vertebrea,
             override=override,
         ),
         seg_path_list,
         output_seg_path_list,
+        loc_path_list,
         max_workers=max_workers,
         chunksize=1,
         disable=quiet,
@@ -293,18 +350,23 @@ def iterative_label_mp(
 def _iterative_label(
         seg_path,
         output_seg_path,
+        loc_path=None,
         disc_labels=[],
         init_disc={},
         output_disc_step=1,
+        loc_disc_labels=[],
         vertebrea_labels=[],
         vertebrea_extra_labels=[],
         init_vertebrae={},
         output_vertebrea_step=1,
+        loc_vertebrea_labels=[],
         map_input_dict={},
         map_output_dict={},
         dilation_size=1,
         step_diff_label=False,
         step_diff_disc=False,
+        default_superior_disc=0,
+        default_superior_vertebrea=0,
         override=False,
     ):
     '''
@@ -312,29 +374,36 @@ def _iterative_label(
     '''
     seg_path = Path(seg_path)
     output_seg_path = Path(output_seg_path)
+    loc_path = loc_path and Path(loc_path)
 
     # If the output image already exists and we are not overriding it, return
     if not override and output_seg_path.exists():
         return
 
-    # Load segmentation
+    # Load segmentation and localizer images
     seg = nib.load(seg_path)
+    loc = loc_path and loc_path.is_file() and nib.load(loc_path)
 
     try:
         output_seg = iterative_label(
             seg,
+            loc,
             disc_labels=disc_labels,
             init_disc=init_disc,
             output_disc_step=output_disc_step,
+            loc_disc_labels=loc_disc_labels,
             vertebrea_labels=vertebrea_labels,
             vertebrea_extra_labels=vertebrea_extra_labels,
             init_vertebrae=init_vertebrae,
             output_vertebrea_step=output_vertebrea_step,
+            loc_vertebrea_labels=loc_vertebrea_labels,
             map_input_dict=map_input_dict,
             map_output_dict=map_output_dict,
             dilation_size=dilation_size,
             step_diff_label=step_diff_label,
             step_diff_disc=step_diff_disc,
+            default_superior_disc=default_superior_disc,
+            default_superior_vertebrea=default_superior_vertebrea,
         )
     except ValueError as e:
         output_seg_path.is_file() and output_seg_path.unlink()
@@ -356,18 +425,23 @@ def _iterative_label(
 
 def iterative_label(
         seg,
+        loc=None,
         disc_labels=[],
         init_disc={},
         output_disc_step=1,
+        loc_disc_labels=[],
         vertebrea_labels=[],
         vertebrea_extra_labels=[],
         init_vertebrae={},
         output_vertebrea_step=1,
+        loc_vertebrea_labels=[],
         map_input_dict={},
         map_output_dict={},
         dilation_size=1,
         step_diff_label=False,
         step_diff_disc=False,
+        default_superior_disc=0,
+        default_superior_vertebrea=0,
     ):
     '''
     Label Vertebrae, IVDs, Spinal Cord and canal from init segmentation.
@@ -383,12 +457,16 @@ def iterative_label(
     ----------
     seg : nibabel.nifti1.Nifti1Image
         Segmentation image
+    loc : nibabel.nifti1.Nifti1Image
+        Localizer image to use for detecting first vertebrea and disc (optional)
     disc_labels : list
         The disc labels
     init_disc : dict
         Init labels list for disc ordered by priority (input_label:output_label)
     output_disc_step : int
         The step to take between disc labels in the output
+    loc_disc_labels : list
+        Localizer labels to use for detecting first disc
     vertebrea_labels : list
         The vertebrae labels
     vertebrea_extra_labels : list
@@ -397,6 +475,8 @@ def iterative_label(
         Init labels list for vertebrae ordered by priority (input_label:output_label)
     output_vertebrea_step : int
         The step to take between vertebrae labels in the output
+    loc_vertebrea_labels : list
+        Localizer labels to use for detecting first vertebrae
     map_input_dict : dict
         A dict mapping labels from input into the output segmentation
     map_output_dict : dict
@@ -407,6 +487,10 @@ def iterative_label(
         Make step only for different labels
     step_diff_disc : bool
         Make step only for different discs
+    default_superior_disc : int
+        Default superior disc label if no init label found
+    default_superior_vertebrea : int
+        Default superior vertebrae label if no init label found
 
     Returns
     -------
@@ -417,15 +501,25 @@ def iterative_label(
 
     output_seg_data = np.zeros_like(seg_data)
 
+    loc_data = loc and np.asanyarray(loc.dataobj).round().astype(np.uint8)
+
+    # If localizer is provided, transform it to the segmentation space
+    if loc_data is not None:
+        loc_data = tio.Resample(
+            tio.ScalarImage(tensor=seg_data[None, ...], affine=seg.affine)
+        )(
+            tio.LabelMap(tensor=loc_data[None, ...], affine=loc.affine)
+        ).data.numpy()[0, ...].astype(np.uint8)
+
     binary_dilation_structure = ndi.iterate_structure(ndi.generate_binary_structure(3, 1), dilation_size)
 
     # Arrays to store the z indexes of the discs sorted superior to inferior
     disc_sorted_z_indexes = []
 
     # We run the same iterative algorithm for discs and vertebrae
-    for labels, extra_labels, step, init, is_vert in (
-        (disc_labels, [], output_disc_step, init_disc, False),
-        (vertebrea_labels, vertebrea_extra_labels, output_vertebrea_step, init_vertebrae, True)):
+    for labels, extra_labels, step, init, default_sup, loc_labels, is_vert in (
+        (disc_labels, [], output_disc_step, init_disc, default_superior_disc, loc_disc_labels, False),
+        (vertebrea_labels, vertebrea_extra_labels, output_vertebrea_step, init_vertebrae, default_superior_vertebrea, loc_vertebrea_labels, True)):
 
         # Skip if no labels are provided
         if len(labels) == 0:
@@ -551,6 +645,27 @@ def iterative_label(
             if k in seg_data:
                 first_label = v - step * sorted_labels.index(mask_labeled[seg_data == k].flat[0])
                 break
+
+        # If no init label found, set it from the localizer
+        if first_label == 0 and loc_data is not None:
+            # Make mask for the intersection of the localizer labels and the labels in the segmentation
+            mask = np.isin(loc_data, loc_labels) * np.isin(mask_labeled, sorted_labels)
+
+            # Get the first label from sorted_labels that is in the localizer specified labels
+            first_sorted_labels_in_loc = next(np.array(sorted_labels)[np.isin(sorted_labels, mask * mask_labeled)].flat, 0)
+
+            if first_sorted_labels_in_loc > 0:
+                # Get the target label in the segmentation
+                loc_data_masked = mask * loc_data
+                target = np.argmax(np.bincount(loc_data_masked[mask_labeled == first_sorted_labels_in_loc].flat))
+                # If target in map_output_dict reverse it from the reversed map
+                # TODO Edge case if multiple keys have the same value, not used in the current implementation
+                target = {v: k for k, v in map_output_dict.items()}.get(target, target)
+                first_label = target - step * sorted_labels.index(first_sorted_labels_in_loc)
+
+        # If no init label found, set the default superior label
+        if first_label == 0 and default_sup > 0:
+            first_label = default_sup
 
         # If no init label found, print error
         if first_label == 0:

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -386,7 +386,7 @@ def _iterative_label(
 
     # Load segmentation and localizer images
     seg = nib.load(seg_path)
-    loc = loc_path and loc_path.is_file() and nib.load(loc_path)
+    loc = loc_path and (loc_path.is_file() or None) and nib.load(loc_path)
 
     try:
         output_seg = iterative_label(

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -82,7 +82,7 @@ def main():
     )
     parser.add_argument(
         '--loc-disc-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
-        help='The disc labels.'
+        help='The disc labels in the localizer used for detecting first disc.'
     )
     parser.add_argument(
         '--vertebrea-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
@@ -102,7 +102,7 @@ def main():
     )
     parser.add_argument(
         '--loc-vertebrea-labels', type=lambda x:list(range(int(x.split('-')[0]), int(x.split('-')[-1]) + 1)), nargs='+', default=[],
-        help='The disc labels.'
+        help='The disc labels in the localizer used for detecting first vertebrae.'
     )
     parser.add_argument(
         '--map-input', type=str, nargs='+', default=[],

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -39,7 +39,7 @@ def main():
     parser.add_argument(
         '--locs-dir', '-l', type=Path, default=None,
         help=' '.join(f'''
-            Folder containing localizers segmentations to use for detecting first vertebrae and disc if init label not found, Optional.
+            Folder containing localizers' segmentations to help the labeling. Optional.
             The algorithm will transform the localizer to the segmentation space and use it to detect the matching vertebrae and disc if the init label not found.
             Mathcing will based on the magority of the voxels of the first vertebrae or disc in the localizer, that intersect with the input segmentation.
         '''.split())


### PR DESCRIPTION
Currently, the iterative_label.py script does not support images without any of the landmarks (C2, T1, T12, Sacrum).
To solve this issue, we can update the iterative_label.py script to get localizer segmentation as an input to initialize labels for discs and vertebrae. The localizer have to be in same space, but no need for exact match, only that most of the voxels in the first vertebrae and disc will be overlapping with the provided image. The script acts as follows:
1. Transform localizer into the image space.
1. For upper vertebrae and upper disc in the localizer:
   1. Get the superior disc/vertebra label from the matched disc/vertebra in localizer.
   1. Loop over the rest of the discs/vertebrae in the input image and map them sequentially as usual.

Instructions for new localizer based labeling:

https://github.com/neuropoly/totalspineseg/blob/07069b9bc1386be46713f71d709898f7631f8c42/README.md#L51-L86

checkout this branch:
```bash
cd totalspineseg && git checkout localizer-based-labeling && cd ..
```

https://github.com/neuropoly/totalspineseg/blob/07069b9bc1386be46713f71d709898f7631f8c42/README.md#L175-L209

![Localizer](https://github.com/user-attachments/assets/5acf0208-a322-46f9-bbde-b3c961a87ec4)