### PR TITLE
Extract posterior tip of the discs during level extraction

### DIFF
--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -477,6 +477,8 @@ def main():
         output_path / 'step1_levels',
         canal_labels=[1, 2],
         disc_labels=list(range(63, 68)) + list(range(71, 83)) + list(range(91, 96)) + [100],
+        c1_label=11,
+        vert_label=50,
         overwrite=True,
         max_workers=max_workers,
         quiet=quiet,

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -478,7 +478,7 @@ def main():
         canal_labels=[1, 2],
         disc_labels=list(range(63, 68)) + list(range(71, 83)) + list(range(91, 96)) + [100],
         c1_label=11,
-        vert_label=50,
+        c2_label=50,
         overwrite=True,
         max_workers=max_workers,
         quiet=quiet,

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -310,20 +310,21 @@ def extract_levels(
         output_seg_data[tuple(idx)] = map_labels[label]
 
     # If C2-C3 and C1 are in the segmentation, set 1 and 2
-    if 3 in output_seg_data and c2_label != 0 and c1_label != 0:
+    if 3 in output_seg_data and c2_label != 0 and c1_label != 0 and all(np.isin([c1_label, c2_label], seg_data)):
         # Place 1 at the top of C2 if C1 is visible in the image
-        if c1_label in seg_data:
-            # Find the location of the C2-C3 disc
-            c2c3_index = np.unravel_index(np.argmax(output_seg_data == 3), seg_data.shape)
+        # Find the location of the C2-C3 disc
+        c2c3_index = np.unravel_index(np.argmax(output_seg_data == 3), seg_data.shape)
 
-            # Find the maximum coordinate of the vertebra C1
-            c1_coords = np.where(seg_data == c1_label)
-            c1_z_max_index = np.max(c1_coords[2])
+        # Find the maximum coordinate of the vertebra C1
+        c1_coords = np.where(seg_data == c1_label)
+        c1_z_max_index = np.max(c1_coords[2])
 
-            # Extract coordinate of the vertebrae
-            # The coordinate of 1 needs to be in the same slice as 3 but below the max index of C1
-            vert_coords = np.where(seg_data[c2c3_index[0],:,:c1_z_max_index] == c2_label)
+        # Extract coordinate of the vertebrae
+        # The coordinate of 1 needs to be in the same slice as 3 but below the max index of C1
+        vert_coords = np.where(seg_data[c2c3_index[0],:,:c1_z_max_index] == c2_label)
 
+        # Check if not empty
+        if len(vert_coords) > 1:
             # Find top pixel of the vertebrae
             argmax_z = np.argmax(vert_coords[1])
             top_vert_voxel = tuple([c2c3_index[0]]+[vert_coords[i][argmax_z] for i in range(2)])

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -226,6 +226,7 @@ def extract_levels(
 
     The function extracts the vertebrae levels from the input segmentation by finding the closest voxel in the canal anteriorline to the middle of each disc.
     The superior voxels of the top vertebrae is set to 1 and the middle voxels between C2-C3 and the superior voxels are set to 2.
+    The generated labeling convention follows the one from SCT (https://spinalcordtoolbox.com/stable/user_section/tutorials/vertebral-labeling/labeling-conventions.html)
 
     Parameters
     ----------

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -55,11 +55,11 @@ def main():
     )
     parser.add_argument(
         '--c1-label', type=int, default=0,
-        help='The label for C1 vertebra in the segmentation, if provided it will be used to determine if C1 is in the segmentation.'
+        help='The label for C1 vertebra in the segmentation, if provided it will be used to extract the level 1.'
     )
     parser.add_argument(
         '--c2-label', type=int, default=0,
-        help='The label that contains the segmentation of the vertebrae C2 (this label may also be used with other vertebrae), if provided it will be used to extract the level 1.'
+        help='The label for C2 vertebra in the segmentation (this label may also be used with other vertebrae), if provided it will be used to extract the level 1.'
     )
     parser.add_argument(
         '--overwrite', '-r', action="store_true", default=False,

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -288,13 +288,12 @@ def extract_levels(
 
     # Find the minimum distance for each disc voxel and the corresponding canal centerline index
     discs_distance_from_centerline = np.min(discs_distances_from_all_centerline, axis=1)
-    discs_centerline_indices = canal_centerline_indices[np.argmin(discs_distances_from_all_centerline, axis=1)]
 
-    # Find the closest canal centerline voxel to each disc label
-    disc_labels_centerline_indices = [discs_centerline_indices[discs_indices_labels == label][np.argmin(discs_distance_from_centerline[discs_indices_labels == label])] for label in disc_labels_in_seg]
+    # Find the closest voxel to the canal centerline for each disc label (posterior tip)
+    disc_labels_indices = [discs_indices[discs_indices_labels == label][np.argmin(discs_distance_from_centerline[discs_indices_labels == label])] for label in disc_labels_in_seg]
 
-    # Set the output labels to the closest canal centerline voxels
-    for idx, label in zip(disc_labels_centerline_indices, disc_labels_in_seg):
+    # Set the output labels to the closest voxel to the canal centerline for each disc
+    for idx, label in zip(disc_labels_indices, disc_labels_in_seg):
         output_seg_data[tuple(idx)] = map_labels[label]
 
     # If C2-C3 is in the segmentation, set 1 and 2 to the superior voxels in the canal centerline and the middle voxels between C2-C3 and the superior voxels

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -329,8 +329,10 @@ def extract_levels(
             argmax_z = np.argmax(vert_coords[1])
             top_vert_voxel = tuple([c2c3_index[0]]+[vert_coords[i][argmax_z] for i in range(2)])
 
-            # Set 1 to the superior voxels
-            output_seg_data[top_vert_voxel] = 1
+            # Set 1 to the superior voxels and project onto the anterior line
+            top_vert_distances_from_all_anteriorline = np.linalg.norm(top_vert_voxel - canal_anteriorline_indices[None, ...], axis=2)
+            top_vert_index_anteriorline = canal_anteriorline_indices[np.argmin(top_vert_distances_from_all_anteriorline, axis=1)]
+            output_seg_data[tuple(top_vert_index_anteriorline[0])] = 1
 
             # Set 2 to the middle voxels between C2-C3 and the superior voxels
             c1c2_index = tuple([(top_vert_voxel[i] + c2c3_index[i]) // 2 for i in range(3)])

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -315,7 +315,7 @@ def extract_levels(
             # Find the location of the C2-C3 disc
             c2c3_index = np.unravel_index(np.argmax(output_seg_data == 3), seg_data.shape)
 
-            # Find the minimum coordinate of the vertebra C1
+            # Find the maximum coordinate of the vertebra C1
             c1_coords = np.where(seg_data == c1_label)
             c1_z_max_index = np.max(c1_coords[2])
 

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -58,6 +58,10 @@ def main():
         help='The label for C1 vertebra in the segmentation, if provided it will be used to determine if C1 is in the segmentation.'
     )
     parser.add_argument(
+        '--vert-label', type=int, default=0,
+        help='The label used for all the vertebrae, if provided it will be used to extract the level 1.'
+    )
+    parser.add_argument(
         '--overwrite', '-r', action="store_true", default=False,
         help='Overwrite existing output files, defaults to false (Do not overwrite).'
     )
@@ -82,6 +86,7 @@ def main():
     canal_labels = args.canal_labels
     disc_labels = [l for raw in args.disc_labels for l in (raw if isinstance(raw, list) else [raw])]
     c1_label = args.c1_label
+    vert_label = args.vert_label
     overwrite = args.overwrite
     max_workers = args.max_workers
     quiet = args.quiet
@@ -98,6 +103,7 @@ def main():
             canal_labels = {canal_labels}
             disc_labels = {disc_labels}
             c1_label = {c1_label}
+            vert_label = {vert_label}
             overwrite = {overwrite}
             max_workers = {max_workers}
             quiet = {quiet}
@@ -112,6 +118,7 @@ def main():
         canal_labels=canal_labels,
         disc_labels=disc_labels,
         c1_label=c1_label,
+        vert_label=vert_label,
         overwrite=overwrite,
         max_workers=max_workers,
         quiet=quiet,
@@ -126,6 +133,7 @@ def extract_levels_mp(
         canal_labels=[],
         disc_labels=[],
         c1_label=0,
+        vert_label=0,
         overwrite=False,
         max_workers=mp.cpu_count(),
         quiet=False,
@@ -148,6 +156,7 @@ def extract_levels_mp(
             canal_labels=canal_labels,
             disc_labels=disc_labels,
             c1_label=c1_label,
+            vert_label=vert_label,
             overwrite=overwrite,
         ),
         seg_path_list,
@@ -163,6 +172,7 @@ def _extract_levels(
         canal_labels=[],
         disc_labels=[],
         c1_label=0,
+        vert_label=0,
         overwrite=False,
     ):
     '''
@@ -184,6 +194,7 @@ def _extract_levels(
             canal_labels=canal_labels,
             disc_labels=disc_labels,
             c1_label=c1_label,
+            vert_label=vert_label,
         )
     except ValueError as e:
         output_seg_path.is_file() and output_seg_path.unlink()
@@ -208,6 +219,7 @@ def extract_levels(
         canal_labels=[],
         disc_labels=[],
         c1_label=0,
+        vert_label=0,
     ):
     '''
     Extract vertebrae levels from Spinal Canal and Discs.

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -332,7 +332,11 @@ def extract_levels(
 
             # Set 2 to the middle voxels between C2-C3 and the superior voxels
             c1c2_index = tuple([(top_vert_voxel[i] + c2c3_index[i]) // 2 for i in range(3)])
-            output_seg_data[c1c2_index] = 2
+
+            # Project 2 on the anterior line
+            c1c2_distances_from_all_centerline = np.linalg.norm(c1c2_index - canal_centerline_indices[None, ...], axis=2)
+            c1c2_index_centerline = canal_centerline_indices[np.argmin(c1c2_distances_from_all_centerline, axis=1)]
+            output_seg_data[tuple(c1c2_index_centerline[0])] = 2
 
     output_seg = nib.Nifti1Image(output_seg_data, seg.affine, seg.header)
 

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -224,8 +224,8 @@ def extract_levels(
     '''
     Extract vertebrae levels from Spinal Canal and Discs.
 
-    The function extracts the vertebrae levels from the input segmentation by finding the closest voxel in the canal centerline to the middle of each disc.
-    The superior voxels in the canal centerline are set to 1 and the middle voxels between C2-C3 and the superior voxels are set to 2.
+    The function extracts the vertebrae levels from the input segmentation by finding the closest voxel in the canal anteriorline to the middle of each disc.
+    The superior voxels of the top vertebrae is set to 1 and the middle voxels between C2-C3 and the superior voxels are set to 2.
 
     Parameters
     ----------

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -58,8 +58,8 @@ def main():
         help='The label for C1 vertebra in the segmentation, if provided it will be used to determine if C1 is in the segmentation.'
     )
     parser.add_argument(
-        '--vert-label', type=int, default=0,
-        help='The label used for all the vertebrae, if provided it will be used to extract the level 1.'
+        '--c2-label', type=int, default=0,
+        help='The label that contains the segmentation of the vertebrae C2 (this label may also be used with other vertebrae), if provided it will be used to extract the level 1.'
     )
     parser.add_argument(
         '--overwrite', '-r', action="store_true", default=False,
@@ -86,7 +86,7 @@ def main():
     canal_labels = args.canal_labels
     disc_labels = [l for raw in args.disc_labels for l in (raw if isinstance(raw, list) else [raw])]
     c1_label = args.c1_label
-    vert_label = args.vert_label
+    c2_label = args.c2_label
     overwrite = args.overwrite
     max_workers = args.max_workers
     quiet = args.quiet
@@ -103,7 +103,7 @@ def main():
             canal_labels = {canal_labels}
             disc_labels = {disc_labels}
             c1_label = {c1_label}
-            vert_label = {vert_label}
+            c2_label = {c2_label}
             overwrite = {overwrite}
             max_workers = {max_workers}
             quiet = {quiet}
@@ -118,7 +118,7 @@ def main():
         canal_labels=canal_labels,
         disc_labels=disc_labels,
         c1_label=c1_label,
-        vert_label=vert_label,
+        c2_label=c2_label,
         overwrite=overwrite,
         max_workers=max_workers,
         quiet=quiet,
@@ -133,7 +133,7 @@ def extract_levels_mp(
         canal_labels=[],
         disc_labels=[],
         c1_label=0,
-        vert_label=0,
+        c2_label=0,
         overwrite=False,
         max_workers=mp.cpu_count(),
         quiet=False,
@@ -156,7 +156,7 @@ def extract_levels_mp(
             canal_labels=canal_labels,
             disc_labels=disc_labels,
             c1_label=c1_label,
-            vert_label=vert_label,
+            c2_label=c2_label,
             overwrite=overwrite,
         ),
         seg_path_list,
@@ -172,7 +172,7 @@ def _extract_levels(
         canal_labels=[],
         disc_labels=[],
         c1_label=0,
-        vert_label=0,
+        c2_label=0,
         overwrite=False,
     ):
     '''
@@ -194,7 +194,7 @@ def _extract_levels(
             canal_labels=canal_labels,
             disc_labels=disc_labels,
             c1_label=c1_label,
-            vert_label=vert_label,
+            c2_label=c2_label,
         )
     except ValueError as e:
         output_seg_path.is_file() and output_seg_path.unlink()
@@ -219,7 +219,7 @@ def extract_levels(
         canal_labels=[],
         disc_labels=[],
         c1_label=0,
-        vert_label=0,
+        c2_label=0,
     ):
     '''
     Extract vertebrae levels from Spinal Canal and Discs.
@@ -309,7 +309,7 @@ def extract_levels(
         output_seg_data[tuple(idx)] = map_labels[label]
 
     # If C2-C3 and C1 are in the segmentation, set 1 and 2
-    if 3 in output_seg_data and vert_label != 0 and c1_label != 0:
+    if 3 in output_seg_data and c2_label != 0 and c1_label != 0:
         # Place 1 at the top of C2 if C1 is visible in the image
         if c1_label in seg_data:
             # Find the location of the C2-C3 disc
@@ -321,7 +321,7 @@ def extract_levels(
 
             # Extract coordinate of the vertebrae
             # The coordinate of 1 needs to be in the same slice as 3 but below the max index of C1
-            vert_coords = np.where(seg_data[c2c3_index[0],:,:c1_z_max_index] == vert_label)
+            vert_coords = np.where(seg_data[c2c3_index[0],:,:c1_z_max_index] == c2_label)
 
             # Find top pixel of the vertebrae
             argmax_z = np.argmax(vert_coords[1])

--- a/totalspineseg/utils/extract_levels.py
+++ b/totalspineseg/utils/extract_levels.py
@@ -324,7 +324,7 @@ def extract_levels(
         vert_coords = np.where(seg_data[c2c3_index[0],:,:c1_z_max_index] == c2_label)
 
         # Check if not empty
-        if len(vert_coords) > 1:
+        if len(vert_coords[1]) > 0:
             # Find top pixel of the vertebrae
             argmax_z = np.argmax(vert_coords[1])
             top_vert_voxel = tuple([c2c3_index[0]]+[vert_coords[i][argmax_z] for i in range(2)])


### PR DESCRIPTION
## Description

This PR replaces the current discs label projection with an extraction of the posterior tip of the discs. The idea is to align the model with the spinalcordtoolbox [convention](https://spinalcordtoolbox.com/user_section/tutorials/vertebral-labeling/labeling-conventions.html) to simplify the futur integration. 

## Method 

As suggested by @yw7, labels are now projected on a shifted canal centerline (toward the posterior edge of the discs). Doing this improves the labeling when discs are not well segmented. The green dots correspond to the labels outputted by this PR.

![Kapture 2024-10-16 at 10 46 07](https://github.com/user-attachments/assets/15266982-ad2e-4512-b75b-7f72649bded5)

> This image was resampled after the level extraction step to the original orientation.

The extraction of the level 1 and 2 was also modified to be more precise and robust.

To be merged instead of https://github.com/neuropoly/totalspineseg/pull/61