### PR TITLE
Add vertebrae level preview option

### DIFF
--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -482,6 +482,18 @@ def main():
         quiet=quiet,
     )
 
+    if not quiet: print('\n' 'Generating preview images for the step 1 levels:')
+    preview_jpg_mp(
+        output_path / 'input',
+        output_path / 'preview',
+        segs_path=output_path / 'step1_levels',
+        output_suffix='_step1_levels_tags',
+        overwrite=True,
+        max_workers=max_workers,
+        quiet=quiet,
+        label_texts_right={i: f'{i}' for i in range(1, 31)},
+    )
+
     if not step1_only:
         if not quiet: print('\n' 'Copying the original images into step 2 input folder:')
         cpdir_mp(

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -488,6 +488,7 @@ def main():
         output_path / 'preview',
         segs_path=output_path / 'step1_levels',
         output_suffix='_step1_levels_tags',
+        levels=True,
         overwrite=True,
         max_workers=max_workers,
         quiet=quiet,

--- a/totalspineseg/utils/preview_jpg.py
+++ b/totalspineseg/utils/preview_jpg.py
@@ -333,7 +333,7 @@ def _preview_jpg(
     if (label_texts_right or label_texts_left) and seg_path and seg_path.is_file():
         draw = ImageDraw.Draw(output_image)
         # Use a bold TrueType font for better sharpness and boldness
-        font = ImageFont.load_default(size=16)
+        font = ImageFont.load_default(size=15)
         width, height = output_image.size
         used_positions = []
         for label in unique_labels:
@@ -439,7 +439,7 @@ def _preview_jpg(
 
     # Make sure output directory exists and save the image
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_image.save(output_path)
+    output_image.save(output_path, quality=95)
 
 if __name__ == '__main__':
     main()

--- a/totalspineseg/utils/preview_jpg.py
+++ b/totalspineseg/utils/preview_jpg.py
@@ -293,9 +293,9 @@ def _preview_jpg(
         seg_data = seg.data.squeeze().numpy().round().astype(np.uint8)
 
         if levels:
-            # Extend the segmentation ortogonal to the orien and dilate 3 voxels to ensure visibility of the levels
-            seg_data = np.broadcast_to(np.max(seg_data, axis=axis, keepdims=True), image_data.shape)
-            # Dilate the segmentation to ensure visibility of the levels
+            # Extend the segmentation ortogonal to orient
+            seg_data = np.broadcast_to(np.max(seg_data, axis=axis, keepdims=True), seg_data.shape)
+            # Dilate 3 voxels to ensure visibility of the levels
             seg_data = ndi.grey_dilation(seg_data, size=(3, 3, 3))
 
         slice_seg = seg_data.take(slice_index, axis=axis)


### PR DESCRIPTION
Introduced a new flag `levels` to preview_jpg.py to extend and dilate segmentation for single voxel segmentations.
Edit inference script to make preview for levels.

![whole_amuPAM50016_T1w_sag_0 5_95](https://github.com/user-attachments/assets/7e48337b-8be5-4245-aa51-a235b01497f1)
