### PR TITLE
Change checkpoint_latest to checkpoint_best in inference script

### DIFF
--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -298,7 +298,7 @@ def main():
     # Get the nnUNet parameters from the results folder
     nnUNetTrainer, nnUNetPlans, configuration = next((nnUNet_results / step1_dataset).glob('*/fold_*')).parent.name.split('__')
     # Check if the final checkpoint exists, if not use the latest checkpoint
-    checkpoint = 'checkpoint_final.pth' if (nnUNet_results / step1_dataset / f'{nnUNetTrainer}__{nnUNetPlans}__{configuration}' / f'fold_{fold}' / 'checkpoint_final.pth').is_file() else 'checkpoint_latest.pth'
+    checkpoint = 'checkpoint_final.pth' if (nnUNet_results / step1_dataset / f'{nnUNetTrainer}__{nnUNetPlans}__{configuration}' / f'fold_{fold}' / 'checkpoint_final.pth').is_file() else 'checkpoint_best.pth'
 
     if not quiet: print('\n' 'Running step 1 model:')
     subprocess.run([
@@ -549,7 +549,7 @@ def main():
         # Get the nnUNet parameters from the results folder
         nnUNetTrainer, nnUNetPlans, configuration = next((nnUNet_results / step2_dataset).glob('*/fold_*')).parent.name.split('__')
         # Check if the final checkpoint exists, if not use the latest checkpoint
-        checkpoint = 'checkpoint_final.pth' if (nnUNet_results / step2_dataset / f'{nnUNetTrainer}__{nnUNetPlans}__{configuration}' / f'fold_{fold}' / 'checkpoint_final.pth').is_file() else 'checkpoint_latest.pth'
+        checkpoint = 'checkpoint_final.pth' if (nnUNet_results / step2_dataset / f'{nnUNetTrainer}__{nnUNetPlans}__{configuration}' / f'fold_{fold}' / 'checkpoint_final.pth').is_file() else 'checkpoint_best.pth'
 
         if not quiet: print('\n' 'Running step 2 model:')
         subprocess.run([


### PR DESCRIPTION
Fixes #78

Change `checkpoint_latest.pth` to `checkpoint_best.pth` in the inference script to match the priority in SCT:.

* Update line 301 in `totalspineseg/inference.py` to use `checkpoint_best.pth` instead of `checkpoint_latest.pth`.
* Update line 552 in `totalspineseg/inference.py` to use `checkpoint_best.pth` instead of `checkpoint_latest.pth`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/neuropoly/totalspineseg/pull/81?shareId=7224368f-f50d-4a26-afed-4514851513ac).