### PR TITLE
Update python version to bypass `nnunetv2` error

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ When not available, sacrum segmentations were generated using the [totalsegmenta
 ## Dependencies
 
 - `bash` terminal
-- [Python](https://www.python.org/) >= 3.9, with pip >= 23 and setuptools >= 67
+- [Python](https://www.python.org/) >= 3.10, with pip >= 23 and setuptools >= 67
 
 ## Installation
 


### PR DESCRIPTION
## Description

`nnunetv2` default installation for python 3.9 leads to an error caused by a missing package. While this error was [solved](https://github.com/MIC-DKFZ/nnUNet/issues/2589) by the nnunet team, the error still remains with python 3.9 default installation. 

This PR update the README to exclude python 3.9 from possible installation for user.

## Related issues

#102 