### PR TITLE
Update README versions for python and pytorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ When not available, sacrum segmentations were generated using the [totalsegmenta
 ## Dependencies
 
 - `bash` terminal
-- [Python](https://www.python.org/) >= 3.9, with pip >= 23 and setuptools >= 67
+- [Python](https://www.python.org/) >= 3.10, with pip >= 23 and setuptools >= 67
 
 ## Installation
 
@@ -76,7 +76,7 @@ cd TotalSpineSeg
    ```
    - conda env
    ```
-   conda create -n myenv python=3.9
+   conda create -n myenv python=3.10
    conda activate myenv
    ```
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ cd TotalSpineSeg
 5. For CUDA GPU support, install **PyTorch<2.6** following the instructions on their [website](https://pytorch.org/). Be sure to add the `--upgrade` flag to your installation command to replace any existing PyTorch installation.
    Example:
 ```bash
-conda install pytorch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1  pytorch-cuda=11.8 -c pytorch -c nvidia --upgrade
+python3 -m pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu118 --upgrade
 ```
 
 6. **OPTIONAL STEP:** Define a folder where weights will be stored:

--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ cd TotalSpineSeg
    python3 -m pip install totalspineseg
    ```
 
-5. For CUDA GPU support, install **PyTorch** following the instructions on their [website](https://pytorch.org/). Be sure to add the `--upgrade` flag to your installation command to replace any existing PyTorch installation.
+5. For CUDA GPU support, install **PyTorch<2.6** following the instructions on their [website](https://pytorch.org/). Be sure to add the `--upgrade` flag to your installation command to replace any existing PyTorch installation.
    Example:
 ```bash
-python3 -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118 --upgrade
+conda install pytorch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1  pytorch-cuda=11.8 -c pytorch -c nvidia --upgrade
 ```
 
 6. **OPTIONAL STEP:** Define a folder where weights will be stored:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "totalspineseg"
-version = "20250205"
+version = "20250224"
 requires-python = ">=3.10"
 description = "TotalSpineSeg is a tool for automatic instance segmentation and labeling of all vertebrae, intervertebral discs (IVDs), spinal cord, and spinal canal in MRI images."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "totalspineseg"
 version = "20250205"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 description = "TotalSpineSeg is a tool for automatic instance segmentation and labeling of all vertebrae, intervertebral discs (IVDs), spinal cord, and spinal canal in MRI images."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Description

`nnunetv2` default installation for python 3.9 leads to an error caused by a missing package. While this error was [solved](https://github.com/MIC-DKFZ/nnUNet/issues/2589) by the nnunet team, the error still remains with python 3.9 default installation. 

This PR update the README to exclude python 3.9 from possible installation for user.

This PR also updates the pytorch requirement asking for an anterior version to 2.6. As it raises an error with nnunet.

## Related issues

- #102 
- https://github.com/neuropoly/totalspineseg/issues/104
- https://github.com/MIC-DKFZ/nnUNet/issues/2681 pytorch 2.6 issue