### PR TITLE
Add `--keep-only` flag parameter to save storage and computation time

### DIFF
--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -185,7 +185,7 @@ def inference(
     step1_only : bool
         If True only the prediction of the first model will be computed.
     keep_only : list of string
-        If not empty, only the folder listed will be kept and some functions won't be computed.
+        If not empty, only the folders listed will be kept and some functions won't be computed.
     max_workers : int
         Max worker to run in parallel proccess, defaults to numer of available cores
     max_workers_nnunet : int
@@ -866,7 +866,7 @@ def inference(
         if not keep_only[0] or folder in keep_only:
             if folder in folder_dict.keys():
                 if not output_iso:
-                    if not quiet: print('\n' f'Resampling {folder} to the input images space:')
+                    if not quiet: print('\n' f'Resampling {folder} to the input space:')
                     transform_seg2image_mp(
                         output_path / 'input_raw',
                         output_path / folder,


### PR DESCRIPTION
## Description  

When running TotalSpineSeg, multiple folders are automatically generated (e.g., step1_output, step1_canal, step1_cord, step1_levels, step2_output, etc.). However, not all of them are always necessary, leading to longer computation times and increased storage usage.  

To optimize efficiency, the `--step1` flag was introduced to compute only the first step. However, step1_canal, step1_cord, and step1_levels are still always generated, even when they may not be needed. Similarly, generating preview after each step is not always essential but is still created.  

## Solution  

This PR introduces a new flag, `--keep-only` (or `-k`), allowing users to specify which folders should be retained at the end of the run, preventing unnecessary functions from being executed.  

By default, all folders will be kept as usual.