### PR TITLE
Fix ValueError: Unknown file type: .test.nii.gz when files have an additional dot in the filename

### DIFF
--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -290,11 +290,11 @@ def inference(
         (output_path / 'input_raw').mkdir(parents=True, exist_ok=True)
 
         # Check suffixes
-        if "".join(input_path.suffixes) == ".nii.gz":
+        if input_path.name.endswith(".nii.gz"):
             # Copy file
             dst_path = output_path / 'input_raw' / input_path.name.replace('.nii.gz', '_0000.nii.gz')
             shutil.copy(input_path, dst_path)
-        elif "".join(input_path.suffixes) == ".nii":
+        elif input_path.suffix == ".nii":
             # Compress file                    
             src_img = nib.load(input_path)
             dst_path = output_path / 'input_raw' / input_path.name.replace('.nii', '_0000.nii.gz')


### PR DESCRIPTION
Fix #110

I encountered an issue while running the code, where files containing additional dots in their filenames (e.g., `file.test.nii.gz`) result in the following error:

```
ValueError: Unknown file type: .test.nii.gz, please use niftii files
```

This happens because the code checks the file suffixes using an incorrect assumption that `.nii.gz` will always be the last two suffixes. For files like `file.test.nii.gz`, the code fails to correctly identify the `.nii.gz` suffix due to the additional dot in the filename.

https://github.com/neuropoly/totalspineseg/blob/6fa7bf62f21486e97d91ecd7eeaa9e9cfb2d8426/totalspineseg/inference.py#L292-L303

---

### Steps to Reproduce
1. Use a file with an additional dot in the filename, e.g., `file.test.nii.gz`.
2. Run the script.
3. Observe the `ValueError`.

---

### Expected Behavior
The code should correctly identify `.nii.gz` files even when the filename contains additional dots.

---

### Suggested Fix
Update the code to handle `.nii.gz` files correctly by modifying the suffix check as follows:

```python
# Check suffixes
if input_path.name.endswith(".nii.gz"):
    # Copy file
    dst_path = output_path / 'input_raw' / input_path.name.replace('.nii.gz', '_0000.nii.gz')
    shutil.copy(input_path, dst_path)
elif input_path.suffix == ".nii":
    # Compress file                    
    src_img = nib.load(input_path)
    dst_path = output_path / 'input_raw' / input_path.name.replace('.nii', '_0000.nii.gz')
    nib.save(src_img, dst_path)
else:
    raise ValueError(f"Unknown file type: {''.join(input_path.suffixes)}, please use niftii files")
```

This fix uses `input_path.name.endswith(".nii.gz")` to correctly identify `.nii.gz` files regardless of the number of dots in the filename, ensuring that files like `file.test.nii.gz` are recognized properly.
