### PR TITLE
Make `nnunetv2` an optional dependency (to allow SCT to replace `nnunetv2` with a fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,16 @@ cd TotalSpineSeg
    > **Note:** If you pull a new version from GitHub, make sure to rerun this command with the flag `--upgrade`
    ```bash
    git clone https://github.com/neuropoly/totalspineseg.git
-   python3 -m pip install -e totalspineseg
+   python3 -m pip install -e totalspineseg[nnunetv2]
    ```
    - PyPI installation (for inference only)
    ```
-   python3 -m pip install totalspineseg
+   python3 -m pip install totalspineseg[nnunetv2]
+   ```
+   - PyPI installation (with specific nnU-Net version)
+   ```bash
+   # Note: Use "[nnunetv2]" to stick to tested versions of nnunetv2
+   python3 -m pip install totalspineseg nnunetv2==2.6.2
    ```
 
 5. For CUDA GPU support, install **PyTorch<2.6** following the instructions on their [website](https://pytorch.org/). Be sure to add the `--upgrade` flag to your installation command to replace any existing PyTorch installation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,23 @@ dependencies = [
     "pillow",
     "nilearn",
     "SimpleITK",
-    "nnunetv2-neuropoly",
     "psutil",
     "blosc2<3.9.0"
 ]
+
+# Allow users to choose whichever version of `nnunetv2` they prefer
+#   - `pip install totalspineseg[nnunetv2]`       (tested, safe versions of `nnunetv2`)
+#   - `pip install totalspineseg nnunetv2==2.6.2` (specific version)
+#   - `pip install totalspineseg[neuropoly]`      (internal fork of `nnunetv2`)
+#
+# Note: Some older versions of `nnunetv2` have notable bugs:
+#   - nnunetv2==2.5.1 fails with nnUNetTrainer_DASegOrd0_NoMirroring
+#     (https://github.com/MIC-DKFZ/nnUNet/issues/2480)  <-- unclear if fixed?
+#   - nnunetv2==2.4.2 fails with --verify-dataset-integrity
+#     (https://github.com/MIC-DKFZ/nnUNet/issues/2144)  <-- fixed in future versions, but non-fatal
+[project.optional-dependencies]
+nnunetv2 = ["nnunetv2<=2.4.2"]
+neuropoly = ["nnunetv2-neuropoly"]
 
 [project.urls]
 homepage = "https://github.com/neuropoly/totalspineseg"


### PR DESCRIPTION
This is a test commit to see if `totalspineseg` will work with our fork of nnunetv2. I will use this branch in combination with https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/5027.