### PR TITLE
Consider landmark if bigger than min_component_size

### DIFF
--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -593,11 +593,17 @@ def iterative_label(
     top_disc_mask = disc_mask_labeled == disc_sorted_labels[0]
     c2_c3_mask = seg_data == 2 # C2-C3
     if not np.any(top_disc_mask & c2_c3_mask): # First disc is C2-C3
-        del selected_disc_landmarks[selected_disc_landmarks.index(2)] # Remove C2-C3 from selected landmarks if it is not the first disc
+        try:
+            selected_disc_landmarks.remove(2) # Remove C2-C3 from selected landmarks if it is not the first disc
+        except ValueError:
+            pass
     bottom_disc_mask = disc_mask_labeled == disc_sorted_labels[-1]
     l5_s1_mask = seg_data == 5 # L5-S1
-    if not np.sum(bottom_disc_mask*l5_s1_mask) > 0 : # Last disc is L5-S1
-        del selected_disc_landmarks[selected_disc_landmarks.index(5)] # Remove L5-S1 from selected landmarks if it is not the last disc
+    if not np.any(bottom_disc_mask & l5_s1_mask): # Last disc is L5-S1
+        try:
+            selected_disc_landmarks.remove(5) # Remove L5-S1 from selected landmarks if it is not the last disc
+        except ValueError:
+            pass
 
     # Get the landmark disc labels and output labels - {label in sorted labels: output label}
     # TODO Currently only the first 2 landmark from selected_disc_landmarks is used, to get all landmarks see TODO in the function

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -589,6 +589,16 @@ def iterative_label(
         mask_aterior_to_canal,
     )
 
+    # Discard C2-C3 and L5-S1 discs if innacurate (e.g. C2-C3 in the middle of the spine or L5-S1 at the top of the spine)
+    top_disc_mask = disc_mask_labeled == disc_sorted_labels[0]
+    c2_c3_mask = seg_data == 2 # C2-C3
+    if not np.sum(top_disc_mask*c2_c3_mask) > 0 : # First disc is C2-C3
+        del selected_disc_landmarks[selected_disc_landmarks.index(2)] # Remove C2-C3 from selected landmarks if it is not the first disc
+    bottom_disc_mask = disc_mask_labeled == disc_sorted_labels[-1]
+    l5_s1_mask = seg_data == 5 # L5-S1
+    if not np.sum(bottom_disc_mask*l5_s1_mask) > 0 : # Last disc is L5-S1
+        del selected_disc_landmarks[selected_disc_landmarks.index(5)] # Remove L5-S1 from selected landmarks if it is not the last disc
+
     # Get the landmark disc labels and output labels - {label in sorted labels: output label}
     # TODO Currently only the first 2 landmark from selected_disc_landmarks is used, to get all landmarks see TODO in the function
     map_disc_sorted_labels_landmark2output = _get_landmark_output_labels(
@@ -1150,4 +1160,29 @@ def _fill(mask):
         ((mask_min_z <= indices[2]) & (indices[2] <= mask_max_z))
 
 if __name__ == '__main__':
+    # iterative_label(
+    #     seg,
+    #     loc=None,
+    #     selected_disc_landmarks=[2,5,3,4],
+    #     disc_labels=[1, 2, 3, 4, 5],
+    #     disc_landmark_labels=[2,3,4,5],
+    #     disc_landmark_output_labels=[63, 71, 91, 100],
+    #     disc_output_step=1,
+    #     vertebrae_labels=[7,8,9],
+    #     vertebrae_landmark_output_labels=[13, 21, 41, 50],
+    #     vertebrae_output_step=1,
+    #     vertebrae_extra_labels=[6],
+    #     region_max_sizes=[5, 12, 6, 1],
+    #     region_default_sizes=[5, 12, 5, 1],
+    #     loc_disc_labels=[],
+    #     canal_labels=[10],
+    #     canal_output_label=2,
+    #     cord_labels=[11],
+    #     cord_output_label=1,
+    #     sacrum_labels=[9],
+    #     sacrum_output_label=50,
+    #     map_input_dict={},
+    #     dilation_size=1,
+    #     disc_default_superior_output=0,
+    # )
     main()

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -593,7 +593,7 @@ def iterative_label(
     for landmark in selected_disc_landmarks:
         landmark_mask = seg_data == landmark
         # Dilate the mask to combine small disconnected regions
-        binary_dilation_structure = ndi.iterate_structure(ndi.generate_binary_structure(3, 1), dilation_size)
+        binary_dilation_structure = ndi.iterate_structure(ndi.generate_binary_structure(3, 1), 5)
         landmark_mask_dilated = ndi.binary_dilation(landmark_mask, binary_dilation_structure)
 
         # Label the connected voxels in the dilated mask into separate labels

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -589,19 +589,6 @@ def iterative_label(
         mask_aterior_to_canal,
     )
 
-    # Check if every landmark is only one component
-    for landmark in selected_disc_landmarks:
-        landmark_mask = seg_data == landmark
-        # Dilate the mask to combine small disconnected regions
-        binary_dilation_structure = ndi.iterate_structure(ndi.generate_binary_structure(3, 1), 5)
-        landmark_mask_dilated = ndi.binary_dilation(landmark_mask, binary_dilation_structure)
-
-        # Label the connected voxels in the dilated mask into separate labels
-        tmp_mask_labeled, tmp_num_labels = ndi.label(landmark_mask_dilated.astype(np.uint32), np.ones((3, 3, 3)))
-        if tmp_num_labels > 1:
-            # Delete landmarks if detected multiple times
-            del selected_disc_landmarks[selected_disc_landmarks.index(landmark)]
-
     # Discard C2-C3 and L5-S1 discs if innacurate (e.g. C2-C3 in the middle of the spine or L5-S1 at the top of the spine)
     top_disc_mask = disc_mask_labeled == disc_sorted_labels[0]
     c2_c3_mask = seg_data == 2 # C2-C3

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -589,6 +589,19 @@ def iterative_label(
         mask_aterior_to_canal,
     )
 
+    # Check if every landmark is only one component
+    for landmark in selected_disc_landmarks:
+        landmark_mask = seg_data == landmark
+        # Dilate the mask to combine small disconnected regions
+        binary_dilation_structure = ndi.iterate_structure(ndi.generate_binary_structure(3, 1), dilation_size)
+        landmark_mask_dilated = ndi.binary_dilation(landmark_mask, binary_dilation_structure)
+
+        # Label the connected voxels in the dilated mask into separate labels
+        tmp_mask_labeled, tmp_num_labels = ndi.label(landmark_mask_dilated.astype(np.uint32), np.ones((3, 3, 3)))
+        if tmp_num_labels > 1:
+            # Delete landmarks if detected multiple times
+            del selected_disc_landmarks[selected_disc_landmarks.index(landmark)]
+
     # Discard C2-C3 and L5-S1 discs if innacurate (e.g. C2-C3 in the middle of the spine or L5-S1 at the top of the spine)
     top_disc_mask = disc_mask_labeled == disc_sorted_labels[0]
     c2_c3_mask = seg_data == 2 # C2-C3

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -1045,6 +1045,7 @@ def _get_landmark_output_labels(
         landmark_output_labels,
         loc_labels,
         default_superior_output,
+        min_component_size=500,
     ):
     '''
     Get dict mapping labels from sorted_labels to the output labels based on the landmarks in the segmentation or localizer.
@@ -1092,15 +1093,17 @@ def _get_landmark_output_labels(
     if len(map_landmark_outputs) == 0:
         for l in selected_landmarks:
             ############################################################################################################
-            # TODO Remove this reake when we trust all the landmarks to get all landmarks instead of the first 2
+            # TODO Remove this break when we trust all the landmarks to get all landmarks instead of the first 2
             if len(map_landmark_outputs) > 0 and selected_landmarks.index(l) > 1:
                 break
             ############################################################################################################
             if l in map_landmark_labels and l in seg_data:
-                mask_labeled_l = np.argmax(np.bincount(mask_labeled[seg_data == l].flat))
-                # We map only if the landmark cover the majority of the voxels in the mask_labeled label
-                if np.argmax(np.bincount(seg_data[mask_seg_data_landmarks & (mask_labeled == mask_labeled_l)].flat)) == l:
-                    map_landmark_outputs[mask_labeled_l] = map_landmark_labels[l]
+                # Check size of the landmark to discard small landmarks that are unlikely to be correct
+                if np.sum(seg_data == l) > min_component_size:
+                    mask_labeled_l = np.argmax(np.bincount(mask_labeled[seg_data == l].flat))
+                    # We map only if the landmark cover the majority of the voxels in the mask_labeled label
+                    if np.argmax(np.bincount(seg_data[mask_seg_data_landmarks & (mask_labeled == mask_labeled_l)].flat)) == l:
+                        map_landmark_outputs[mask_labeled_l] = map_landmark_labels[l]
 
     # If no init label found, set the default superior label
     if len(map_landmark_outputs) == 0 and default_superior_output > 0:

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -592,7 +592,7 @@ def iterative_label(
     # Discard C2-C3 and L5-S1 discs if innacurate (e.g. C2-C3 in the middle of the spine or L5-S1 at the top of the spine)
     top_disc_mask = disc_mask_labeled == disc_sorted_labels[0]
     c2_c3_mask = seg_data == 2 # C2-C3
-    if not np.sum(top_disc_mask*c2_c3_mask) > 0 : # First disc is C2-C3
+    if not np.any(top_disc_mask & c2_c3_mask): # First disc is C2-C3
         del selected_disc_landmarks[selected_disc_landmarks.index(2)] # Remove C2-C3 from selected landmarks if it is not the first disc
     bottom_disc_mask = disc_mask_labeled == disc_sorted_labels[-1]
     l5_s1_mask = seg_data == 5 # L5-S1


### PR DESCRIPTION
## Description

The aim of this PR is to get rid of small unreliable landmarks before the iterative labeling step to avoid errors.

New checks:
- landmarks must have a minimum shape to avoid noisy predictions
- c2-c3 must be the top most disc and l5-s1 but be the bottom most disc

## Related issues

- https://github.com/neuropoly/totalspineseg/issues/130
- https://github.com/neuropoly/totalspineseg/pull/131