### PR TITLE
Interrupt processing if `step1` fails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "totalspineseg"
-version = "20260414"
+version = "20260429"
 requires-python = ">=3.10"
 description = "TotalSpineSeg is a tool for automatic instance segmentation and labeling of all vertebrae, intervertebral discs (IVDs), spinal cord, and spinal canal in MRI images."
 readme = "README.md"

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -534,7 +534,7 @@ def inference(
 
     # Stop execution if step1_output is empty
     if not any((output_path / 'step1_output').glob('*.nii.gz')):
-        raise ValueError('\n' 'Error: TotalSpineSeg step 1 failed to produce a valid segmentation resulting in an empty prediction.' \
+        raise ValueError('TotalSpineSeg step 1 failed to produce a valid segmentation resulting in an empty prediction.' \
                             ' The input data is likely too different from the training data, and the model failed to detect the anatomy.' \
                             ' Feel free to open an issue on the GitHub repository for assistance.\n') 
 

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -532,6 +532,13 @@ def inference(
             quiet=quiet,
         )
 
+    # Stop execution if step1_output is empty
+    if not any((output_path / 'step1_output').glob('*.nii.gz')):
+        if not quiet: print('\n' 'Error: TotalSpineSeg step 1 failed to produce a valid segmentation resulting in an empty prediction.' \
+                            ' The input data is likely too different from the training data, and the model failed to detect the anatomy.' \
+                            ' Feel free to open an issue on the GitHub repository for assistance.\n')
+        return
+
     if not quiet: print('\n' 'Filling spinal canal label to include all non cord spinal canal:')
     # This will put the spinal canal label in all the voxels between the canal and the cord.
     fill_canal_mp(

--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -534,10 +534,9 @@ def inference(
 
     # Stop execution if step1_output is empty
     if not any((output_path / 'step1_output').glob('*.nii.gz')):
-        if not quiet: print('\n' 'Error: TotalSpineSeg step 1 failed to produce a valid segmentation resulting in an empty prediction.' \
+        raise ValueError('\n' 'Error: TotalSpineSeg step 1 failed to produce a valid segmentation resulting in an empty prediction.' \
                             ' The input data is likely too different from the training data, and the model failed to detect the anatomy.' \
-                            ' Feel free to open an issue on the GitHub repository for assistance.\n')
-        return
+                            ' Feel free to open an issue on the GitHub repository for assistance.\n') 
 
     if not quiet: print('\n' 'Filling spinal canal label to include all non cord spinal canal:')
     # This will put the spinal canal label in all the voxels between the canal and the cord.


### PR DESCRIPTION
## Description

This PR aims to stop TotalSpineSeg execution if the first model fails to produce a prediction.

## Related issues

https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/5163#issuecomment-3886997253