### PR TITLE
Fix error on multiple invocations of inference(...) using CUDA

### DIFF
--- a/totalspineseg/inference.py
+++ b/totalspineseg/inference.py
@@ -262,7 +262,12 @@ def inference(
         elif device == 'cuda':
             # multithreading in torch doesn't help nnU-Net if run on GPU
             torch.set_num_threads(1)
-            torch.set_num_interop_threads(1)
+            try:
+                torch.set_num_interop_threads(1)
+            except RuntimeError as e:
+                # It's only possible to set the number of threads for interop parallelism once.
+                if "cannot set number of interop threads" not in str(e):
+                    raise
             device = torch.device('cuda')
         else:
             device = torch.device('mps')


### PR DESCRIPTION
Hi,

This PR fixes #140 by catching the RuntimeError raised when torch.set_num_interop_threads(1) is called multiple times within the same Python process.

While most users likely interact with TotalSpineSeg through the command-line interface, this issue affects library usage, where multiple calls to totalspineseg.inference.inference(...) within the same Python runtime currently fail.

This seemed like the simplest fix. However, it may be preferable to prevent repeated calls to torch.set_num_interop_threads(1) altogether rather than catching the resulting exception.

Any feedback on the implementation is appreciated.