### PR TITLE
Fix bug with sacrum discs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "totalspineseg"
-version = "20260730"
+version = "20260807"
 requires-python = ">=3.10"
 description = "TotalSpineSeg is a tool for automatic instance segmentation and labeling of all vertebrae, intervertebral discs (IVDs), spinal cord, and spinal canal in MRI images."
 readme = "README.md"

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -594,7 +594,7 @@ def iterative_label(
         mask_aterior_to_canal,
     )
 
-    # Discard C2-C3 and L5-S1 discs if innacurate (e.g. C2-C3 in the middle of the spine or L5-S1 at the top of the spine)
+    # Discard C2-C3 if not the top most disc (e.g. C2-C3 in the middle of the spine)
     top_disc_mask = disc_mask_labeled == disc_sorted_labels[0]
     c2_c3_mask = seg_data == 2 # C2-C3
     if not np.any(top_disc_mask & c2_c3_mask): # First disc is C2-C3
@@ -602,13 +602,23 @@ def iterative_label(
             selected_disc_landmarks.remove(2) # Remove C2-C3 from selected landmarks if it is not the first disc
         except ValueError:
             pass
-    bottom_disc_mask = disc_mask_labeled == disc_sorted_labels[-1]
+
+    # Discard L5-S1 if not the bottom most disc (e.g. L5-S1 in the middle of the spine)
     l5_s1_mask = seg_data == 5 # L5-S1
-    if not np.any(bottom_disc_mask & l5_s1_mask): # Last disc is L5-S1
-        try:
-            selected_disc_landmarks.remove(5) # Remove L5-S1 from selected landmarks if it is not the last disc
-        except ValueError:
-            pass
+    l5_s1_disc_mask = l5_s1_mask & (disc_mask_labeled > 0)
+    if np.any(l5_s1_disc_mask):
+        l5_s1_label = disc_mask_labeled[l5_s1_disc_mask][0]
+        l5_s1_index = disc_sorted_labels.index(l5_s1_label)
+
+        if len(disc_sorted_labels)-1 > l5_s1_index: # L5-S1 is not the last disc
+            # Check if following discs can be sacrum discs, if so, we can keep L5-S1 as a landmark
+            following_discs_labels = disc_sorted_labels[l5_s1_index+1:]
+            following_discs_size = [np.sum(disc_mask_labeled == l) for l in following_discs_labels]
+            if any(10*s > np.sum(l5_s1_mask) for s in following_discs_size): # Check if discs is bigger than 10% of L5-S1
+                try:
+                    selected_disc_landmarks.remove(5) # Remove L5-S1 from selected landmarks if it is not the last disc
+                except ValueError:
+                    pass
 
     # Get the landmark disc labels and output labels - {label in sorted labels: output label}
     # TODO Currently only the first 2 landmark from selected_disc_landmarks is used, to get all landmarks see TODO in the function
@@ -622,6 +632,7 @@ def iterative_label(
         disc_landmark_output_labels,
         loc_disc_labels,
         disc_default_superior_output,
+        min_component_size,
     )
 
     # Build a list containing all possible labels for the disc ordered superio-inferior

--- a/totalspineseg/utils/iterative_label.py
+++ b/totalspineseg/utils/iterative_label.py
@@ -468,6 +468,7 @@ def iterative_label(
         map_input_dict={},
         dilation_size=1,
         disc_default_superior_output=0,
+        min_component_size=200
     ):
     '''
     Label Vertebrae, IVDs, Spinal Cord and canal from init segmentation.
@@ -530,6 +531,8 @@ def iterative_label(
         Number of voxels to dilate before finding connected voxels to label
     default_superior_disc : int
         Default superior disc label if no init label found
+    min_component_size : int
+        Minimum size of a component to be considered
 
     Returns
     -------
@@ -554,6 +557,7 @@ def iterative_label(
         mask_aterior_to_canal,
         dilation_size,
         combine_labels=True,
+        min_component_size=min_component_size
     )
 
     # Get sorted connected components superio-inferior (SI) for the vertebrae labels
@@ -563,6 +567,7 @@ def iterative_label(
         canal_centerline_indices,
         mask_aterior_to_canal,
         dilation_size,
+        min_component_size=min_component_size
     )
 
     # Combine sequential vertebrae labels if they have the same value in the original segmentation
@@ -871,6 +876,7 @@ def _get_si_sorted_components(
         mask_aterior_to_canal=None,
         dilation_size=1,
         combine_labels=False,
+        min_component_size=200,
     ):
     '''
     Get sorted connected components superio-inferior (SI) for the given labels in the segmentation.
@@ -905,12 +911,12 @@ def _get_si_sorted_components(
         # Undo dilation
         tmp_mask_labeled *= mask
 
-        # Remove really small components (less than 10 voxels)
+        # Remove really small components (less than min_component_size voxels)
         tmp_mask_labeled_filtered = np.zeros_like(tmp_mask_labeled)
         relabel_counter = 1
         for tmp_label in range(1, tmp_num_labels + 1):
             component_size = np.sum(tmp_mask_labeled == tmp_label)
-            if component_size >= 10:
+            if component_size >= min_component_size:
                 tmp_mask_labeled_filtered[tmp_mask_labeled == tmp_label] = relabel_counter
                 relabel_counter += 1
         


### PR DESCRIPTION
## Description

This PR fixes a bug where the L5–S1 landmark was incorrectly discarded due to the presence of segmented discs within the sacrum.

This issue was introduced in #132, where the L5–S1 landmark was discarded if it was not the bottom-most detected disc, as a safeguard against incorrect landmarks (e.g., an L5–S1 landmark detected in the middle of the spine).

With this fix, discs smaller than 10% of the L5–S1 disc size are excluded from this check, preventing small spurious disc segmentations in the sacrum from causing the L5–S1 landmark to be incorrectly discarded.

| Before this PR | After this PR |
| :---: | :---: |
| <img width="249" height="248" alt="sub-RESTORE_066_ses-B_acq-isotropic_T2w_sag_0 5_step1_output_tags" src="https://github.com/user-attachments/assets/d90f11b6-34ca-4880-8965-5136ffbf623b" /> | <img width="249" height="248" alt="sub-RESTORE_066_ses-B_acq-isotropic_T2w_sag_0 5_step1_output_tags" src="https://github.com/user-attachments/assets/91830ffd-0335-421a-b49e-8851ff403f75" /> |
| <img width="249" height="249" alt="sub-RESTORE_111_ses-A_acq-isotropic_T2w_sag_0 5_step2_output_tags" src="https://github.com/user-attachments/assets/23a17292-4577-4f6b-9650-8fa5fba5cc82" /> | <img width="249" height="249" alt="sub-RESTORE_111_ses-A_acq-isotropic_T2w_sag_0 5_step2_output_tags" src="https://github.com/user-attachments/assets/2fd62ec6-b720-4a16-8b65-c4e3f8407f74" /> |